### PR TITLE
Fix goal definition problem in 2pffa.

### DIFF
--- a/war/root/games/2pffa/2pffa.kif
+++ b/war/root/games/2pffa/2pffa.kif
@@ -222,6 +222,7 @@
 (captureplus 7 8)
 (captureplus 8 9)
 (captureplus 9 10)
+(captureplus 10 10) ; If we capture additional pieces after the tenth, keep a count of 10
 (scoremap 0 0)
 (scoremap 1 10)
 (scoremap 2 20)


### PR DESCRIPTION
It was possible to lose a player's count if they captured more
than 10 pieces.
