### PR TITLE
Fix 9BTTT w/Pie bug spotted by Richard

### DIFF
--- a/war/root/games/nineBoardTicTacToePie/v1/nineBoardTicTacToe.kif
+++ b/war/root/games/nineBoardTicTacToePie/v1/nineBoardTicTacToe.kif
@@ -1,0 +1,253 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; 9 Board Tic Tac Toe with Pie-rule (by Andrew Rose, based on Sam Schreiber's
+;;; version)
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; ROLE Relations
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(role red)
+(role blue)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; BASE & INPUT Relations
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+  (<= (base (mark ?i ?j ?k ?l x))
+      (index ?i)
+      (index ?j)
+      (index ?k)
+      (index ?l))
+
+  (<= (base (mark ?i ?j ?k ?l o))
+      (index ?i)
+      (index ?j)
+      (index ?k)
+      (index ?l))
+
+  (<= (base (currentBoard ?i ?j))
+      (index ?i)
+      (index ?j))
+
+  (<= (base (control ?r))
+      (role ?r))
+
+  (<= (base (usingMarker ?r ?m))
+      (role ?r)
+      (marker ?m))
+
+  (base canSwap)
+
+  (<= (input ?r (play ?i ?j ?k ?l x))
+      (role ?r)
+      (index ?i)
+      (index ?j)
+      (index ?k)
+      (index ?l))
+
+  (<= (input ?r (play ?i ?j ?k ?l o))
+      (role ?r)
+      (index ?i)
+      (index ?j)
+      (index ?k)
+      (index ?l))
+
+  (<= (input ?r noop)
+      (role ?r))
+
+  (<= (input ?r swap)
+      (role ?r))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; INIT Relations
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(init (control red))
+(init (usingMarker red x))
+(init (usingMarker blue o))
+(init canSwap)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; LEGAL Relations
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(<= (legal red noop)
+ (true (control blue)))
+
+(<= (legal blue noop)
+ (true (control red)))
+
+(<= (legal blue swap)
+ (true (control blue))
+ (true canSwap))
+
+(<= (legal ?r (play ?i ?j ?k ?l ?m))
+ (true (control ?r))
+ firstMove
+ (true (usingMarker ?r ?m))
+ (emptyCell ?i ?j ?k ?l))
+
+(<= (legal ?r (play ?i ?j ?k ?l ?m))
+ (true (control ?r))
+ (true (currentBoard ?i ?j))
+ (true (usingMarker ?r ?m))
+ (emptyCell ?i ?j ?k ?l))
+
+(<= (legal ?r (play ?i ?j ?k ?l ?m))
+ (true (control ?r))
+ currentBoardClosed
+ (true (usingMarker ?r ?m))
+ (emptyCell ?i ?j ?k ?l))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; NEXT Relations
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(<= (next (mark ?i ?j ?k ?l ?mark))
+ (role ?player)
+ (does ?player (play ?i ?j ?k ?l ?mark)))
+
+(<= (next (mark ?i ?j ?k ?l ?mark))
+ (true (mark ?i ?j ?k ?l ?mark)))
+
+
+(<= (next (control red))
+ (true (control blue)))
+
+(<= (next (control blue))
+ (true (control red)))
+
+
+(<= (next (currentBoard ?k ?l))
+ (role ?player)
+ (does ?player (play ?i ?j ?k ?l ?mark)))
+
+(<= (next (currentBoard ?k ?l))
+ (true (currentBoard ?k ?l))
+ (does blue swap))
+
+
+(<= (next (usingMarker ?r ?m))
+ (true (usingMarker ?r ?m))
+ (not (does blue swap)))
+
+(<= (next (usingMarker red o))
+ (does blue swap))
+
+(<= (next (usingMarker blue x))
+ (does blue swap))
+
+
+(<= (next canSwap)
+ (true canSwap)
+ (does blue noop))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; TERMINAL Relations
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(<= terminal
+ (line x))
+(<= terminal
+ (line o))
+(<= terminal
+ (not open))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; GOAL Relations
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(<= (goal ?r 100)
+ (true (usingMarker ?r ?m))
+ (line ?m))
+
+(<= (goal ?r 50)
+ (role ?r)
+ (not (line x))
+ (not (line o))
+ (not open))
+
+(<= (goal ?r 0)
+ (role ?r)
+ (not (goal ?r 100))
+ (not (goal ?r 50)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; View Definitions
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(<= (row ?i ?j ?k ?mark)
+ (true (mark ?i ?j ?k 1 ?mark))
+ (true (mark ?i ?j ?k 2 ?mark))
+ (true (mark ?i ?j ?k 3 ?mark)))
+(<= (col ?i ?j ?k ?mark)
+ (true (mark ?i ?j 1 ?k ?mark))
+ (true (mark ?i ?j 2 ?k ?mark))
+ (true (mark ?i ?j 3 ?k ?mark)))
+(<= (diag ?i ?j ?mark)
+ (true (mark ?i ?j 1 1 ?mark))
+ (true (mark ?i ?j 2 2 ?mark))
+ (true (mark ?i ?j 3 3 ?mark)))
+(<= (diag ?i ?j ?mark)
+ (true (mark ?i ?j 1 3 ?mark))
+ (true (mark ?i ?j 2 2 ?mark))
+ (true (mark ?i ?j 3 1 ?mark)))
+
+(<= (line ?mark)
+ (index ?i)
+ (index ?j)
+ (index ?k)
+ (row ?i ?j ?k ?mark))
+(<= (line ?mark)
+ (index ?i)
+ (index ?j)
+ (index ?k)
+ (col ?i ?j ?k ?mark))
+(<= (line ?mark)
+ (index ?i)
+ (index ?j)
+ (diag ?i ?j ?mark))
+
+(<= (emptyCell ?i ?j ?k ?l)
+ (index ?i)
+ (index ?j)
+ (index ?k)
+ (index ?l)
+ (not (true (mark ?i ?j ?k ?l x)))
+ (not (true (mark ?i ?j ?k ?l o))))
+
+(<= open (emptyCell ?i ?j ?k ?l))
+
+(<= currentBoardClosed
+ (true (currentBoard ?i ?j))
+ (not (emptyCell ?i ?j 1 1))
+ (not (emptyCell ?i ?j 1 2))
+ (not (emptyCell ?i ?j 1 3))
+ (not (emptyCell ?i ?j 2 1))
+ (not (emptyCell ?i ?j 2 2))
+ (not (emptyCell ?i ?j 2 3))
+ (not (emptyCell ?i ?j 3 1))
+ (not (emptyCell ?i ?j 3 2))
+ (not (emptyCell ?i ?j 3 3)))
+
+(<= firstMove
+ (not (true (currentBoard 1 1)))
+ (not (true (currentBoard 1 2)))
+ (not (true (currentBoard 1 3)))
+ (not (true (currentBoard 2 1)))
+ (not (true (currentBoard 2 2)))
+ (not (true (currentBoard 2 3)))
+ (not (true (currentBoard 3 1)))
+ (not (true (currentBoard 3 2)))
+ (not (true (currentBoard 3 3))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Static Relations
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(index 1) (index 2) (index 3)
+(marker x) (marker o)
+


### PR DESCRIPTION
Don't lose the currentBoard when the second player accepts the pie swap.  Just adds the additional rule...

(<= (next (currentBoard ?k ?l))
 (true (currentBoard ?k ?l))
 (does blue swap))
