### PR TITLE
Fix stylesheets that used \r line endings

### DIFF
--- a/war/root/games/2pffa/2pffa.xsl
+++ b/war/root/games/2pffa/2pffa.xsl
@@ -1,1 +1,114 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.142"/>px;        height: <xsl:value-of select="$height * 0.142"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="7"/>      <xsl:with-param name="rows" select="7"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$row"/>    <xsl:value-of select="$col"/>      </xsl:attribute>    <xsl:if test="$row=1 or $row=7 or $col=1 or $col=7">    <xsl:attribute name="style">background-color: #222</xsl:attribute>  </xsl:if>    <center>  <xsl:choose>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:when>  </xsl:choose>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.142"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="7"/>
+      <xsl:with-param name="rows" select="7"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$row"/>
+    <xsl:value-of select="$col"/>    
+  </xsl:attribute>
+  
+  <xsl:if test="$row=1 or $row=7 or $col=1 or $col=7">
+    <xsl:attribute name="style">background-color: #222</xsl:attribute>
+  </xsl:if>  
+
+  <center>
+  <xsl:choose>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:when>
+  </xsl:choose>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/2pffa_zerosum/2pffa_zerosum.xsl
+++ b/war/root/games/2pffa_zerosum/2pffa_zerosum.xsl
@@ -1,1 +1,114 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.142"/>px;        height: <xsl:value-of select="$height * 0.142"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="7"/>      <xsl:with-param name="rows" select="7"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$row"/>    <xsl:value-of select="$col"/>      </xsl:attribute>    <xsl:if test="$row=1 or $row=7 or $col=1 or $col=7">    <xsl:attribute name="style">background-color: #222</xsl:attribute>  </xsl:if>    <center>  <xsl:choose>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:when>  </xsl:choose>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.142"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="7"/>
+      <xsl:with-param name="rows" select="7"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$row"/>
+    <xsl:value-of select="$col"/>    
+  </xsl:attribute>
+  
+  <xsl:if test="$row=1 or $row=7 or $col=1 or $col=7">
+    <xsl:attribute name="style">background-color: #222</xsl:attribute>
+  </xsl:if>  
+
+  <center>
+  <xsl:choose>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:when>
+  </xsl:choose>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/2pttc/2pttc.xsl
+++ b/war/root/games/2pttc/2pttc.xsl
@@ -1,1 +1,115 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.142"/>px;        height: <xsl:value-of select="$height * 0.142"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="7"/>      <xsl:with-param name="rows" select="7"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$row"/>    <xsl:value-of select="$col"/>      </xsl:attribute>  <xsl:choose>    <xsl:when test="$row=1 or $row=7 or $col=1 or $col=7"> <xsl:attribute name="style">background-color: #222</xsl:attribute> </xsl:when>    <xsl:when test="$row=2 or $row=6 or $col=2 or $col=6"> <xsl:attribute name="style">background-color: #888</xsl:attribute> </xsl:when>  </xsl:choose>    <center>  <xsl:choose>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:when>  </xsl:choose>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.142"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="7"/>
+      <xsl:with-param name="rows" select="7"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$row"/>
+    <xsl:value-of select="$col"/>    
+  </xsl:attribute>
+
+  <xsl:choose>
+    <xsl:when test="$row=1 or $row=7 or $col=1 or $col=7"> <xsl:attribute name="style">background-color: #222</xsl:attribute> </xsl:when>
+    <xsl:when test="$row=2 or $row=6 or $col=2 or $col=6"> <xsl:attribute name="style">background-color: #888</xsl:attribute> </xsl:when>
+  </xsl:choose>  
+
+  <center>
+  <xsl:choose>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:when>
+  </xsl:choose>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/3pConnectFour/3pConnectFour.xsl
+++ b/war/root/games/3pConnectFour/3pConnectFour.xsl
@@ -1,1 +1,107 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="6"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='yellow']"> <img class="piece" src="&ROOT;/resources/images/discs/yellow.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="7 - $row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="6"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='yellow']"> <img class="piece" src="&ROOT;/resources/images/discs/yellow.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="7 - $row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/3pffa/3pffa.xsl
+++ b/war/root/games/3pffa/3pffa.xsl
@@ -1,1 +1,115 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.142"/>px;        height: <xsl:value-of select="$height * 0.142"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="7"/>      <xsl:with-param name="rows" select="7"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$row"/>    <xsl:value-of select="$col"/>      </xsl:attribute>    <xsl:if test="$row=1 or $row=7 or $col=1 or $col=7">    <xsl:attribute name="style">background-color: #222</xsl:attribute>  </xsl:if>    <center>  <xsl:choose>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='yellow']"> <img class="piece" src="&ROOT;/resources/images/discs/yellow.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:when>  </xsl:choose>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.142"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="7"/>
+      <xsl:with-param name="rows" select="7"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$row"/>
+    <xsl:value-of select="$col"/>    
+  </xsl:attribute>
+  
+  <xsl:if test="$row=1 or $row=7 or $col=1 or $col=7">
+    <xsl:attribute name="style">background-color: #222</xsl:attribute>
+  </xsl:if>  
+
+  <center>
+  <xsl:choose>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='yellow']"> <img class="piece" src="&ROOT;/resources/images/discs/yellow.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:when>
+  </xsl:choose>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/3pttc/3pttc.xsl
+++ b/war/root/games/3pttc/3pttc.xsl
@@ -1,1 +1,116 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.142"/>px;        height: <xsl:value-of select="$height * 0.142"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="7"/>      <xsl:with-param name="rows" select="7"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$row"/>    <xsl:value-of select="$col"/>      </xsl:attribute>  <xsl:choose>    <xsl:when test="$row=1 or $row=7 or $col=1 or $col=7"> <xsl:attribute name="style">background-color: #222</xsl:attribute> </xsl:when>    <xsl:when test="$row=2 or $row=6 or $col=2 or $col=6"> <xsl:attribute name="style">background-color: #888</xsl:attribute> </xsl:when>  </xsl:choose>    <center>  <xsl:choose>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='yellow']"> <img class="piece" src="&ROOT;/resources/images/discs/yellow.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:when>  </xsl:choose>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.142"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="7"/>
+      <xsl:with-param name="rows" select="7"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$row"/>
+    <xsl:value-of select="$col"/>    
+  </xsl:attribute>
+
+  <xsl:choose>
+    <xsl:when test="$row=1 or $row=7 or $col=1 or $col=7"> <xsl:attribute name="style">background-color: #222</xsl:attribute> </xsl:when>
+    <xsl:when test="$row=2 or $row=6 or $col=2 or $col=6"> <xsl:attribute name="style">background-color: #888</xsl:attribute> </xsl:when>
+  </xsl:choose>  
+
+  <center>
+  <xsl:choose>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='yellow']"> <img class="piece" src="&ROOT;/resources/images/discs/yellow.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:when>
+  </xsl:choose>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/4pffa/4pffa.xsl
+++ b/war/root/games/4pffa/4pffa.xsl
@@ -1,1 +1,116 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.142"/>px;        height: <xsl:value-of select="$height * 0.142"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="7"/>      <xsl:with-param name="rows" select="7"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$row"/>    <xsl:value-of select="$col"/>      </xsl:attribute>    <xsl:if test="$row=1 or $row=7 or $col=1 or $col=7">    <xsl:attribute name="style">background-color: #222</xsl:attribute>  </xsl:if>      <center>  <xsl:choose>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='yellow']"> <img class="piece" src="&ROOT;/resources/images/discs/yellow.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='green']"> <img class="piece" src="&ROOT;/resources/images/discs/green.png"/> </xsl:when>  </xsl:choose>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.142"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="7"/>
+      <xsl:with-param name="rows" select="7"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$row"/>
+    <xsl:value-of select="$col"/>    
+  </xsl:attribute>
+  
+  <xsl:if test="$row=1 or $row=7 or $col=1 or $col=7">
+    <xsl:attribute name="style">background-color: #222</xsl:attribute>
+  </xsl:if>    
+
+  <center>
+  <xsl:choose>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='yellow']"> <img class="piece" src="&ROOT;/resources/images/discs/yellow.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='green']"> <img class="piece" src="&ROOT;/resources/images/discs/green.png"/> </xsl:when>
+  </xsl:choose>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/4pttc/4pttc.xsl
+++ b/war/root/games/4pttc/4pttc.xsl
@@ -1,1 +1,117 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.142"/>px;        height: <xsl:value-of select="$height * 0.142"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="7"/>      <xsl:with-param name="rows" select="7"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$row"/>    <xsl:value-of select="$col"/>      </xsl:attribute>    <xsl:choose>    <xsl:when test="$row=1 or $row=7 or $col=1 or $col=7"> <xsl:attribute name="style">background-color: #222</xsl:attribute> </xsl:when>    <xsl:when test="$row=2 or $row=6 or $col=2 or $col=6"> <xsl:attribute name="style">background-color: #888</xsl:attribute> </xsl:when>  </xsl:choose>    <center>  <xsl:choose>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='yellow']"> <img class="piece" src="&ROOT;/resources/images/discs/yellow.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='green']"> <img class="piece" src="&ROOT;/resources/images/discs/green.png"/> </xsl:when>  </xsl:choose>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.142"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="7"/>
+      <xsl:with-param name="rows" select="7"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$row"/>
+    <xsl:value-of select="$col"/>    
+  </xsl:attribute>
+  
+  <xsl:choose>
+    <xsl:when test="$row=1 or $row=7 or $col=1 or $col=7"> <xsl:attribute name="style">background-color: #222</xsl:attribute> </xsl:when>
+    <xsl:when test="$row=2 or $row=6 or $col=2 or $col=6"> <xsl:attribute name="style">background-color: #888</xsl:attribute> </xsl:when>
+  </xsl:choose>
+  
+  <center>
+  <xsl:choose>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='yellow']"> <img class="piece" src="&ROOT;/resources/images/discs/yellow.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='blue']"> <img class="piece" src="&ROOT;/resources/images/discs/blue.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='green']"> <img class="piece" src="&ROOT;/resources/images/discs/green.png"/> </xsl:when>
+  </xsl:choose>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/amazons/amazons.xsl
+++ b/war/root/games/amazons/amazons.xsl
@@ -1,1 +1,112 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.1"/>px;        height: <xsl:value-of select="$height * 0.1"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.1"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.1"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="10"/>      <xsl:with-param name="rows" select="10"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='arrow']">    <xsl:attribute name="style">background-color: #222</xsl:attribute>  </xsl:if>  <center>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.1"/>px;
+        height: <xsl:value-of select="$height * 0.1"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.1"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.1"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="10"/>
+      <xsl:with-param name="rows" select="10"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='arrow']">
+    <xsl:attribute name="style">background-color: #222</xsl:attribute>
+  </xsl:if>
+
+  <center>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/amazonsSuicide/amazonsSuicide.xsl
+++ b/war/root/games/amazonsSuicide/amazonsSuicide.xsl
@@ -1,1 +1,112 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.1"/>px;        height: <xsl:value-of select="$height * 0.1"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.1"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.1"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="10"/>      <xsl:with-param name="rows" select="10"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='arrow']">    <xsl:attribute name="style">background-color: #222</xsl:attribute>  </xsl:if>  <center>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.1"/>px;
+        height: <xsl:value-of select="$height * 0.1"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.1"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.1"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="10"/>
+      <xsl:with-param name="rows" select="10"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='arrow']">
+    <xsl:attribute name="style">background-color: #222</xsl:attribute>
+  </xsl:if>
+
+  <center>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/amazonsTorus/amazonsTorus.xsl
+++ b/war/root/games/amazonsTorus/amazonsTorus.xsl
@@ -1,1 +1,112 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.1"/>px;        height: <xsl:value-of select="$height * 0.1"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.1"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.1"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="10"/>      <xsl:with-param name="rows" select="10"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='arrow']">    <xsl:attribute name="style">background-color: #222</xsl:attribute>  </xsl:if>  <center>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.1"/>px;
+        height: <xsl:value-of select="$height * 0.1"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.1"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.1"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="10"/>
+      <xsl:with-param name="rows" select="10"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='arrow']">
+    <xsl:attribute name="style">background-color: #222</xsl:attribute>
+  </xsl:if>
+
+  <center>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/battle/battle.xsl
+++ b/war/root/games/battle/battle.xsl
@@ -1,1 +1,111 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>      </xsl:attribute>    <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='np']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='sp']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='nk']"> <img class="piece" src="&ROOT;/resources/images/checkers/red_king.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='sk']"> <img class="piece" src="&ROOT;/resources/images/checkers/black_king.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>    
+  </xsl:attribute>
+  
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='np']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='sp']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='nk']"> <img class="piece" src="&ROOT;/resources/images/checkers/red_king.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='sk']"> <img class="piece" src="&ROOT;/resources/images/checkers/black_king.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/beatMania/beatMania.xsl
+++ b/war/root/games/beatMania/beatMania.xsl
@@ -1,1 +1,151 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.333"/>px;        height: <xsl:value-of select="$height * 0.033 -2"/>px;        border: 1px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="3"/>      <xsl:with-param name="rows" select="31"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <xsl:if test="$row != 31 or $col = 1">    <td class="cell">    <xsl:attribute name="id">      <xsl:value-of select="'cell_'"/>      <xsl:value-of select="$col"/>      <xsl:value-of select="$row"/>    </xsl:attribute>    <xsl:if test="//fact[relation='block' and argument[1]=$col and argument[2]=$row]">      <xsl:if test="$row = 1">        <xsl:attribute name="style">background-color: #F00</xsl:attribute>      </xsl:if>      <xsl:if test="$row != 1">        <xsl:attribute name="style">background-color: #777</xsl:attribute>      </xsl:if>      </xsl:if>    <xsl:if test="$row = 31">      <xsl:attribute name="colspan">3</xsl:attribute>            <div style="text-align: center">        So far        <xsl:text> </xsl:text>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='0']">0</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='1']">1</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='2']">2</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='3']">3</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='4']">4</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='5']">5</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='6']">6</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='7']">7</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='8']">8</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='9']">9</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='10']">10</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='11']">11</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='12']">12</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='13']">13</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='14']">14</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='15']">15</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='16']">16</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='17']">17</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='18']">18</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='19']">19</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='20']">20</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='21']">21</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='22']">22</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='23']">23</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='24']">24</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='25']">25</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='26']">26</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='27']">27</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='28']">28</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='29']">29</xsl:if>        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='30']">30</xsl:if>        <xsl:text> </xsl:text>        pieces caught      </div>    </xsl:if>  </td>  </xsl:if>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.333"/>px;
+        height: <xsl:value-of select="$height * 0.033 -2"/>px;
+        border: 1px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="3"/>
+      <xsl:with-param name="rows" select="31"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  <xsl:if test="$row != 31 or $col = 1">
+  
+  <td class="cell">
+    <xsl:attribute name="id">
+      <xsl:value-of select="'cell_'"/>
+      <xsl:value-of select="$col"/>
+      <xsl:value-of select="$row"/>
+    </xsl:attribute>
+
+    <xsl:if test="//fact[relation='block' and argument[1]=$col and argument[2]=$row]">
+      <xsl:if test="$row = 1">
+        <xsl:attribute name="style">background-color: #F00</xsl:attribute>
+      </xsl:if>
+      <xsl:if test="$row != 1">
+        <xsl:attribute name="style">background-color: #777</xsl:attribute>
+      </xsl:if>  
+    </xsl:if>
+    <xsl:if test="$row = 31">
+      <xsl:attribute name="colspan">3</xsl:attribute>
+      
+      <div style="text-align: center">
+        So far
+        <xsl:text> </xsl:text>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='0']">0</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='1']">1</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='2']">2</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='3']">3</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='4']">4</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='5']">5</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='6']">6</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='7']">7</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='8']">8</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='9']">9</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='10']">10</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='11']">11</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='12']">12</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='13']">13</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='14']">14</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='15']">15</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='16']">16</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='17']">17</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='18']">18</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='19']">19</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='20']">20</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='21']">21</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='22']">22</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='23']">23</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='24']">24</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='25']">25</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='26']">26</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='27']">27</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='28']">28</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='29']">29</xsl:if>
+        <xsl:if test="//fact[relation='blocksCaught' and argument[1]='30']">30</xsl:if>
+        <xsl:text> </xsl:text>
+        pieces caught
+      </div>
+    </xsl:if>
+  </td>
+
+  </xsl:if>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/biddingTicTacToe/biddingTicTacToe.xsl
+++ b/war/root/games/biddingTicTacToe/biddingTicTacToe.xsl
@@ -1,1 +1,142 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.2"/>px;        height: <xsl:value-of select="$height * 0.2"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;        text-align: center;        font-weight: bold;        font-size: <xsl:value-of select="$width * 0.6 * 0.2"/>px;              }      table.board {        background-color: #000000;      }      div.small {        font-size: <xsl:value-of select="$width * 0.6 * 0.1"/>px;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="5"/>      <xsl:with-param name="rows" select="5"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <xsl:if test="$col=1 or $col=2 or $col=3 or $row=1 or $row=2 or $row=3 or $row=4">    <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>    <xsl:if test="$row=1 or $row=5 or $col=1 or $col=5">    <xsl:attribute name="style">background-color: #222</xsl:attribute>  </xsl:if>  <xsl:if test="$row=5 and $col=1">    <xsl:attribute name="style">background-color: #777</xsl:attribute>    <xsl:attribute name="colspan">2</xsl:attribute>    <div class="small">x =      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='0']">0</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='1']">1</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='2']">2</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='3']">3</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='4']">4</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='5']">5</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='6']">6</xsl:if>      <xsl:if test="//fact[relation='tiebreaker' and argument[1]='x']">*</xsl:if>    </div>  </xsl:if>  <xsl:if test="$row=5 and $col=3">    <xsl:attribute name="style">background-color: #777</xsl:attribute>    <xsl:attribute name="colspan">2</xsl:attribute>    <div class="small">o =      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='0']">0</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='1']">1</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='2']">2</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='3']">3</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='4']">4</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='5']">5</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='6']">6</xsl:if>      <xsl:if test="//fact[relation='tiebreaker' and argument[1]='o']">*</xsl:if>    </div>  </xsl:if>  <xsl:if test="//fact[relation='cell' and (argument[1]+1)=$col and (argument[2]+1)=$row and argument[3]='x']">X</xsl:if>  <xsl:if test="//fact[relation='cell' and (argument[1]+1)=$col and (argument[2]+1)=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>    </td>    </xsl:if>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.2"/>px;
+        height: <xsl:value-of select="$height * 0.2"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+        text-align: center;
+        font-weight: bold;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.2"/>px;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+      div.small {
+        font-size: <xsl:value-of select="$width * 0.6 * 0.1"/>px;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="5"/>
+      <xsl:with-param name="rows" select="5"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  <xsl:if test="$col=1 or $col=2 or $col=3 or $row=1 or $row=2 or $row=3 or $row=4">
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+  
+  <xsl:if test="$row=1 or $row=5 or $col=1 or $col=5">
+    <xsl:attribute name="style">background-color: #222</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="$row=5 and $col=1">
+    <xsl:attribute name="style">background-color: #777</xsl:attribute>
+    <xsl:attribute name="colspan">2</xsl:attribute>
+    <div class="small">x =
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='0']">0</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='1']">1</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='2']">2</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='3']">3</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='4']">4</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='5']">5</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='6']">6</xsl:if>
+      <xsl:if test="//fact[relation='tiebreaker' and argument[1]='x']">*</xsl:if>
+    </div>
+  </xsl:if>
+  <xsl:if test="$row=5 and $col=3">
+    <xsl:attribute name="style">background-color: #777</xsl:attribute>
+    <xsl:attribute name="colspan">2</xsl:attribute>
+    <div class="small">o =
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='0']">0</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='1']">1</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='2']">2</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='3']">3</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='4']">4</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='5']">5</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='6']">6</xsl:if>
+      <xsl:if test="//fact[relation='tiebreaker' and argument[1]='o']">*</xsl:if>
+    </div>
+  </xsl:if>
+
+  <xsl:if test="//fact[relation='cell' and (argument[1]+1)=$col and (argument[2]+1)=$row and argument[3]='x']">X</xsl:if>
+  <xsl:if test="//fact[relation='cell' and (argument[1]+1)=$col and (argument[2]+1)=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>
+  
+  </td>  
+  </xsl:if>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/biddingTicTacToe_10coins/biddingTicTacToe_10coins.xsl
+++ b/war/root/games/biddingTicTacToe_10coins/biddingTicTacToe_10coins.xsl
@@ -1,1 +1,170 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.2"/>px;        height: <xsl:value-of select="$height * 0.2"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;        font-size: <xsl:value-of select="$width * 0.6 * 0.2"/>px;        text-align: center;        font-weight: bold;              }      table.board {        background-color: #000000;      }      div.small {        font-size: <xsl:value-of select="$width * 0.6 * 0.1"/>px;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="5"/>      <xsl:with-param name="rows" select="5"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <xsl:if test="$col=1 or $col=2 or $col=3 or $row=1 or $row=2 or $row=3 or $row=4">    <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>    <xsl:if test="$row=1 or $row=5 or $col=1 or $col=5">    <xsl:attribute name="style">background-color: #222</xsl:attribute>  </xsl:if>  <xsl:if test="$row=5 and $col=1">    <xsl:attribute name="style">background-color: #777</xsl:attribute>    <xsl:attribute name="colspan">2</xsl:attribute>    <div class="small">x =      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='0']">0</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='1']">1</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='2']">2</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='3']">3</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='4']">4</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='5']">5</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='6']">6</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='7']">7</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='8']">8</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='9']">9</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='10']">10</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='11']">11</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='12']">12</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='13']">13</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='14']">14</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='15']">15</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='16']">16</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='17']">17</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='18']">18</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='19']">19</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='20']">20</xsl:if>      <xsl:if test="//fact[relation='tiebreaker' and argument[1]='x']">*</xsl:if>    </div>  </xsl:if>  <xsl:if test="$row=5 and $col=3">    <xsl:attribute name="style">background-color: #777</xsl:attribute>    <xsl:attribute name="colspan">2</xsl:attribute>    <div class="small">o =      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='0']">0</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='1']">1</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='2']">2</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='3']">3</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='4']">4</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='5']">5</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='6']">6</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='7']">7</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='8']">8</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='9']">9</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='10']">10</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='11']">11</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='12']">12</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='13']">13</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='14']">14</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='15']">15</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='16']">16</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='17']">17</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='18']">18</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='19']">19</xsl:if>      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='20']">20</xsl:if>            <xsl:if test="//fact[relation='tiebreaker' and argument[1]='o']">*</xsl:if>    </div>  </xsl:if>  <xsl:if test="//fact[relation='cell' and (argument[1]+1)=$col and (argument[2]+1)=$row and argument[3]='x']">X</xsl:if>  <xsl:if test="//fact[relation='cell' and (argument[1]+1)=$col and (argument[2]+1)=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>    </td>    </xsl:if>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.2"/>px;
+        height: <xsl:value-of select="$height * 0.2"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.2"/>px;
+        text-align: center;
+        font-weight: bold;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+      div.small {
+        font-size: <xsl:value-of select="$width * 0.6 * 0.1"/>px;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="5"/>
+      <xsl:with-param name="rows" select="5"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  <xsl:if test="$col=1 or $col=2 or $col=3 or $row=1 or $row=2 or $row=3 or $row=4">
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+  
+  <xsl:if test="$row=1 or $row=5 or $col=1 or $col=5">
+    <xsl:attribute name="style">background-color: #222</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="$row=5 and $col=1">
+    <xsl:attribute name="style">background-color: #777</xsl:attribute>
+    <xsl:attribute name="colspan">2</xsl:attribute>
+    <div class="small">x =
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='0']">0</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='1']">1</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='2']">2</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='3']">3</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='4']">4</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='5']">5</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='6']">6</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='7']">7</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='8']">8</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='9']">9</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='10']">10</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='11']">11</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='12']">12</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='13']">13</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='14']">14</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='15']">15</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='16']">16</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='17']">17</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='18']">18</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='19']">19</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='x' and argument[2]='20']">20</xsl:if>
+      <xsl:if test="//fact[relation='tiebreaker' and argument[1]='x']">*</xsl:if>
+    </div>
+  </xsl:if>
+  <xsl:if test="$row=5 and $col=3">
+    <xsl:attribute name="style">background-color: #777</xsl:attribute>
+    <xsl:attribute name="colspan">2</xsl:attribute>
+    <div class="small">o =
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='0']">0</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='1']">1</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='2']">2</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='3']">3</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='4']">4</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='5']">5</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='6']">6</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='7']">7</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='8']">8</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='9']">9</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='10']">10</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='11']">11</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='12']">12</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='13']">13</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='14']">14</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='15']">15</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='16']">16</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='17']">17</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='18']">18</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='19']">19</xsl:if>
+      <xsl:if test="//fact[relation='coins' and argument[1]='o' and argument[2]='20']">20</xsl:if>      
+      <xsl:if test="//fact[relation='tiebreaker' and argument[1]='o']">*</xsl:if>
+    </div>
+  </xsl:if>
+
+  <xsl:if test="//fact[relation='cell' and (argument[1]+1)=$col and (argument[2]+1)=$row and argument[3]='x']">X</xsl:if>
+  <xsl:if test="//fact[relation='cell' and (argument[1]+1)=$col and (argument[2]+1)=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>
+  
+  </td>  
+  </xsl:if>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/blocker/blocker.xsl
+++ b/war/root/games/blocker/blocker.xsl
@@ -1,1 +1,114 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.166"/>px;        height: <xsl:value-of select="$height * 0.166"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="6"/>      <xsl:with-param name="rows" select="6"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <xsl:param name="real_row" select="-1+$row"/>  <xsl:param name="real_col" select="-1+$col"/>  <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$real_col"/>    <xsl:value-of select="$real_row"/>  </xsl:attribute>    <xsl:if test="//fact[relation='cell' and argument[1]=$real_col and argument[2]=$real_row and argument[3]='blk']">  	<xsl:attribute name="style">background-color: #4488FF</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$real_col and argument[2]=$real_row and argument[3]='crosser']">  	<xsl:attribute name="style">background-color: #55FF55</xsl:attribute>    </xsl:if>  <xsl:if test="$row = 1 or $row = 6">  	<xsl:attribute name="style">background-color: #4488FF</xsl:attribute>  </xsl:if>  <xsl:if test="($col = 1 or $col = 6) and not($row = 1 or $row = 6)">  	<xsl:attribute name="style">background-color: #55FF55</xsl:attribute>    </xsl:if>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.166"/>px;
+        height: <xsl:value-of select="$height * 0.166"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="6"/>
+      <xsl:with-param name="rows" select="6"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <xsl:param name="real_row" select="-1+$row"/>
+  <xsl:param name="real_col" select="-1+$col"/>
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$real_col"/>
+    <xsl:value-of select="$real_row"/>
+  </xsl:attribute>  
+  <xsl:if test="//fact[relation='cell' and argument[1]=$real_col and argument[2]=$real_row and argument[3]='blk']">
+  	<xsl:attribute name="style">background-color: #4488FF</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$real_col and argument[2]=$real_row and argument[3]='crosser']">
+  	<xsl:attribute name="style">background-color: #55FF55</xsl:attribute>  
+  </xsl:if>
+  <xsl:if test="$row = 1 or $row = 6">
+  	<xsl:attribute name="style">background-color: #4488FF</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="($col = 1 or $col = 6) and not($row = 1 or $row = 6)">
+  	<xsl:attribute name="style">background-color: #55FF55</xsl:attribute>  
+  </xsl:if>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/bomberman2p/bomberman2p.xsl
+++ b/war/root/games/bomberman2p/bomberman2p.xsl
@@ -1,1 +1,135 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: none;        background-color: #CCCCCC;      }      table.board {        background-color: #000000;        border-collapse: collapse;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>    <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">    <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px;</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">    <xsl:attribute name="style">border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">    <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">      <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px; border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>    </xsl:if>        </xsl:if>  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='bomb3']">    <xsl:attribute name="style">background-color: #3F3</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='bomb2']">    <xsl:attribute name="style">background-color: #3B3</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='bomb1']">    <xsl:attribute name="style">background-color: #393</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='bomb0']">    <xsl:attribute name="style">background-color: #363</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='fire']">    <xsl:attribute name="style">background-color: #F00</xsl:attribute>  </xsl:if>  <center>  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='bomberman']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='bomberwoman']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: none;
+        background-color: #CCCCCC;
+      }
+      table.board {
+        background-color: #000000;
+        border-collapse: collapse;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+  
+  <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">
+    <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px;</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">
+    <xsl:attribute name="style">border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">
+    <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">
+      <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px; border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>
+    </xsl:if>      
+  </xsl:if>
+
+  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='bomb3']">
+    <xsl:attribute name="style">background-color: #3F3</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='bomb2']">
+    <xsl:attribute name="style">background-color: #3B3</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='bomb1']">
+    <xsl:attribute name="style">background-color: #393</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='bomb0']">
+    <xsl:attribute name="style">background-color: #363</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='fire']">
+    <xsl:attribute name="style">background-color: #F00</xsl:attribute>
+  </xsl:if>
+
+  <center>
+  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='bomberman']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='bomberwoman']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/breakthrough/breakthrough.xsl
+++ b/war/root/games/breakthrough/breakthrough.xsl
@@ -1,1 +1,108 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/breakthroughHoles/breakthroughHoles.xsl
+++ b/war/root/games/breakthroughHoles/breakthroughHoles.xsl
@@ -1,1 +1,112 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='cellOffLimits' and argument[1]=$col and argument[2]=$row]">    <xsl:attribute name="style">background-color: #222</xsl:attribute>  </xsl:if>  <center>  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='cellOffLimits' and argument[1]=$col and argument[2]=$row]">
+    <xsl:attribute name="style">background-color: #222</xsl:attribute>
+  </xsl:if>
+
+  <center>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/breakthroughSmall/breakthroughSmall.xsl
+++ b/war/root/games/breakthroughSmall/breakthroughSmall.xsl
@@ -1,1 +1,108 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.167"/>px;        height: <xsl:value-of select="$height * 0.167"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.167"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.167"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="6"/>      <xsl:with-param name="rows" select="6"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.167"/>px;
+        height: <xsl:value-of select="$height * 0.167"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.167"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.167"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="6"/>
+      <xsl:with-param name="rows" select="6"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/breakthroughSmallHoles/breakthroughSmallHoles.xsl
+++ b/war/root/games/breakthroughSmallHoles/breakthroughSmallHoles.xsl
@@ -1,1 +1,112 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.167"/>px;        height: <xsl:value-of select="$height * 0.167"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.167"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.167"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="6"/>      <xsl:with-param name="rows" select="6"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='hole']">    <xsl:attribute name="style">background-color: #222</xsl:attribute>  </xsl:if>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.167"/>px;
+        height: <xsl:value-of select="$height * 0.167"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.167"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.167"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="6"/>
+      <xsl:with-param name="rows" select="6"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='hole']">
+    <xsl:attribute name="style">background-color: #222</xsl:attribute>
+  </xsl:if>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/breakthroughSuicide/breakthrough.xsl
+++ b/war/root/games/breakthroughSuicide/breakthrough.xsl
@@ -1,1 +1,108 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/breakthroughSuicideSmall/breakthroughSuicideSmall.xsl
+++ b/war/root/games/breakthroughSuicideSmall/breakthroughSuicideSmall.xsl
@@ -1,1 +1,108 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.167"/>px;        height: <xsl:value-of select="$height * 0.167"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.167"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.167"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="6"/>      <xsl:with-param name="rows" select="6"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.167"/>px;
+        height: <xsl:value-of select="$height * 0.167"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.167"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.167"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="6"/>
+      <xsl:with-param name="rows" select="6"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/breakthroughWalls/breakthroughWalls.xsl
+++ b/war/root/games/breakthroughWalls/breakthroughWalls.xsl
@@ -1,1 +1,108 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/cephalopodMicro/cephalopodMicro.xsl
+++ b/war/root/games/cephalopodMicro/cephalopodMicro.xsl
@@ -1,1 +1,114 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.333"/>px;        height: <xsl:value-of select="$height * 0.333"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        font-size: <xsl:value-of select="$width * 0.6 * 0.333"/>px;        text-align: center;        align: center;		font-weight: bold;              }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="3"/>      <xsl:with-param name="rows" select="3"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1' and argument[4]='red']"><font color="#CC0000">1</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2' and argument[4]='red']"><font color="#CC0000">2</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3' and argument[4]='red']"><font color="#CC0000">3</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4' and argument[4]='red']"><font color="#CC0000">4</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='5' and argument[4]='red']"><font color="#CC0000">5</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='6' and argument[4]='red']"><font color="#CC0000">6</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1' and argument[4]='black']"><font color="#000000">1</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2' and argument[4]='black']"><font color="#000000">2</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3' and argument[4]='black']"><font color="#000000">3</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4' and argument[4]='black']"><font color="#000000">4</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='5' and argument[4]='black']"><font color="#000000">5</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='6' and argument[4]='black']"><font color="#000000">6</font></xsl:if>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.333"/>px;
+        height: <xsl:value-of select="$height * 0.333"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.333"/>px;
+        text-align: center;
+        align: center;
+		font-weight: bold;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="3"/>
+      <xsl:with-param name="rows" select="3"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1' and argument[4]='red']"><font color="#CC0000">1</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2' and argument[4]='red']"><font color="#CC0000">2</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3' and argument[4]='red']"><font color="#CC0000">3</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4' and argument[4]='red']"><font color="#CC0000">4</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='5' and argument[4]='red']"><font color="#CC0000">5</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='6' and argument[4]='red']"><font color="#CC0000">6</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1' and argument[4]='black']"><font color="#000000">1</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2' and argument[4]='black']"><font color="#000000">2</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3' and argument[4]='black']"><font color="#000000">3</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4' and argument[4]='black']"><font color="#000000">4</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='5' and argument[4]='black']"><font color="#000000">5</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='6' and argument[4]='black']"><font color="#000000">6</font></xsl:if>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/checkers/checkers.xsl
+++ b/war/root/games/checkers/checkers.xsl
@@ -1,1 +1,116 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>  <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col_char"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="($row + $col) mod 2 = 0">    <xsl:attribute name="style">background-color: #555555</xsl:attribute>    </xsl:if>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wk']"> <img class="piece" src="&ROOT;/resources/images/checkers/red_king.png"/> </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bk']"> <img class="piece" src="&ROOT;/resources/images/checkers/black_king.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col_char"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+  <xsl:if test="($row + $col) mod 2 = 0">
+    <xsl:attribute name="style">background-color: #555555</xsl:attribute>  
+  </xsl:if>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wk']"> <img class="piece" src="&ROOT;/resources/images/checkers/red_king.png"/> </xsl:if>  
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bk']"> <img class="piece" src="&ROOT;/resources/images/checkers/black_king.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/checkersSmall/checkersSmall.xsl
+++ b/war/root/games/checkersSmall/checkersSmall.xsl
@@ -1,1 +1,116 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="6"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f')"/>  <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col_char"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="($row + $col) mod 2 = 0">    <xsl:attribute name="style">background-color: #555555</xsl:attribute>    </xsl:if>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wk']"> <img class="piece" src="&ROOT;/resources/images/checkers/red_king.png"/> </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bk']"> <img class="piece" src="&ROOT;/resources/images/checkers/black_king.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="6"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f')"/>
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col_char"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+  <xsl:if test="($row + $col) mod 2 = 0">
+    <xsl:attribute name="style">background-color: #555555</xsl:attribute>  
+  </xsl:if>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wk']"> <img class="piece" src="&ROOT;/resources/images/checkers/red_king.png"/> </xsl:if>  
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bk']"> <img class="piece" src="&ROOT;/resources/images/checkers/black_king.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/checkersTiny/checkersTiny.xsl
+++ b/war/root/games/checkersTiny/checkersTiny.xsl
@@ -1,1 +1,116 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="4"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <xsl:param name="col_char" select="translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d')"/>  <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col_char"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="($row + $col) mod 2 = 0">    <xsl:attribute name="style">background-color: #555555</xsl:attribute>    </xsl:if>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wk']"> <img class="piece" src="&ROOT;/resources/images/checkers/red_king.png"/> </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bk']"> <img class="piece" src="&ROOT;/resources/images/checkers/black_king.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="4"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <xsl:param name="col_char" select="translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d')"/>
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col_char"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+  <xsl:if test="($row + $col) mod 2 = 0">
+    <xsl:attribute name="style">background-color: #555555</xsl:attribute>  
+  </xsl:if>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wk']"> <img class="piece" src="&ROOT;/resources/images/checkers/red_king.png"/> </xsl:if>  
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bk']"> <img class="piece" src="&ROOT;/resources/images/checkers/black_king.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/chess/chess.xsl
+++ b/war/root/games/chess/chess.xsl
@@ -1,1 +1,120 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>  <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col_char"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wr']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wk']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wq']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wb']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='br']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bk']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bq']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bb']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col_char"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wr']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wk']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wq']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wb']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='br']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bk']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bq']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bb']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/chickentictactoe/chickentictactoe.xsl
+++ b/war/root/games/chickentictactoe/chickentictactoe.xsl
@@ -1,1 +1,104 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.333"/>px;        height: <xsl:value-of select="$height * 0.333"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        font-size: <xsl:value-of select="$width * 0.6 * 0.333"/>px;        text-align: center;        font-weight: bold;        align: center;              }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="3"/>      <xsl:with-param name="rows" select="3"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.333"/>px;
+        height: <xsl:value-of select="$height * 0.333"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.333"/>px;
+        text-align: center;
+        font-weight: bold;
+        align: center;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="3"/>
+      <xsl:with-param name="rows" select="3"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/chineseCheckers1/chineseCheckers.xsl
+++ b/war/root/games/chineseCheckers1/chineseCheckers.xsl
@@ -1,1 +1,184 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">					#main					{						position:   relative;						width:  <xsl:value-of select="$width"/>px;						height: <xsl:value-of select="$height"/>px;						padding:    10px;						border:     2px solid #b17735;						background: transparent url(&ROOT;/resources/images/chineseCheckers/ccboard.png) repeat top left; 					}							div.teal					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #00ffff;					}					div.red					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ff0000;					}					div.blue					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #0000ff;					}					div.green					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #00ff00;					}					div.yellow					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ffff00;					}					div.magenta					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ff00ff;					}					div.blank					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #cca083;					}					#a1,#i1					{						margin-left: <xsl:value-of select="$width * 0.428571429"/>px;						clear: left;					}					#b1,#h1					{						margin-left: <xsl:value-of select="$width * 0.357142857"/>px;						float: left;						clear: left;					}					#c1,#g1					{						margin-left: 0px;						clear: left;						float: left;					}					#d1,#f1					{						margin-left: <xsl:value-of select="$width * 0.0714285714"/>px;						clear: left;						float: left;					}					#e1					{						margin-left: <xsl:value-of select="$width * 0.142857143"/>px;						clear: left;						float: left;					}      img.piece {      	width: <xsl:value-of select="$width * 0.142857143"/>px;      	height: <xsl:value-of select="$height * 0.113"/>px;           }					    </style>        <div id="main">    	<xsl:call-template name="cell"><xsl:with-param name="loc">a1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">b1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">b2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c7</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g7</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">h1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">h2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">i1</xsl:with-param></xsl:call-template>    </div>   </div>  </xsl:template><xsl:template name="cell">  <xsl:param name="loc" select="a1"/>  <div style="float: left">	<xsl:attribute name="id"><xsl:value-of select="$loc"/></xsl:attribute>	  <xsl:for-each select="//fact[relation='cell' and argument[1]=$loc]">			<xsl:choose>			    <xsl:when test="argument[2]='yellow'">				<xsl:attribute name="class">yellow</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>			</xsl:when>		    <xsl:when test="argument[2]='magenta'">				<xsl:attribute name="class">magenta</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>	 	    <xsl:when test="argument[2]='teal'">				<xsl:attribute name="class">teal</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='green'">				<xsl:attribute name="class">green</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='red'">				<xsl:attribute name="class">red</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='blue'">				<xsl:attribute name="class">blue</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:otherwise>		    	<!-- Old-style blank space, where there's an explicit representation of the blank square -->				<xsl:attribute name="class">blank</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>		  	</xsl:otherwise>		</xsl:choose>	</xsl:for-each>	<xsl:if test="not (//fact[relation='cell' and argument[1]=$loc])">    	<!-- New-style blank space, with no explicit representation in the XML -->    	<xsl:attribute name="class">blank</xsl:attribute>		<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>    </xsl:if>  </div></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+					#main
+					{
+						position:   relative;
+						width:  <xsl:value-of select="$width"/>px;
+						height: <xsl:value-of select="$height"/>px;
+						padding:    10px;
+						border:     2px solid #b17735;
+						background: transparent url(&ROOT;/resources/images/chineseCheckers/ccboard.png) repeat top left; 
+					}		
+					div.teal
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #00ffff;
+					}
+					div.red
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ff0000;
+					}
+					div.blue
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #0000ff;
+					}
+					div.green
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #00ff00;
+					}
+					div.yellow
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ffff00;
+					}
+					div.magenta
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ff00ff;
+					}
+					div.blank
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #cca083;
+					}
+					#a1,#i1
+					{
+						margin-left: <xsl:value-of select="$width * 0.428571429"/>px;
+						clear: left;
+					}
+					#b1,#h1
+					{
+						margin-left: <xsl:value-of select="$width * 0.357142857"/>px;
+						float: left;
+						clear: left;
+					}
+					#c1,#g1
+					{
+						margin-left: 0px;
+						clear: left;
+						float: left;
+					}
+					#d1,#f1
+					{
+						margin-left: <xsl:value-of select="$width * 0.0714285714"/>px;
+						clear: left;
+						float: left;
+					}
+					#e1
+					{
+						margin-left: <xsl:value-of select="$width * 0.142857143"/>px;
+						clear: left;
+						float: left;
+					}
+      img.piece {
+      	width: <xsl:value-of select="$width * 0.142857143"/>px;
+      	height: <xsl:value-of select="$height * 0.113"/>px;     
+      }					
+    </style>
+    
+    <div id="main">
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">a1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">b1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">b2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c7</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g7</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">h1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">h2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">i1</xsl:with-param></xsl:call-template>
+    </div> 
+
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell">
+  <xsl:param name="loc" select="a1"/>
+
+  <div style="float: left">
+	<xsl:attribute name="id"><xsl:value-of select="$loc"/></xsl:attribute>
+	  <xsl:for-each select="//fact[relation='cell' and argument[1]=$loc]">
+			<xsl:choose>
+			    <xsl:when test="argument[2]='yellow'">
+				<xsl:attribute name="class">yellow</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+			</xsl:when>
+		    <xsl:when test="argument[2]='magenta'">
+				<xsl:attribute name="class">magenta</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+	 	    <xsl:when test="argument[2]='teal'">
+				<xsl:attribute name="class">teal</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='green'">
+				<xsl:attribute name="class">green</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='red'">
+				<xsl:attribute name="class">red</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='blue'">
+				<xsl:attribute name="class">blue</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:otherwise>
+		    	<!-- Old-style blank space, where there's an explicit representation of the blank square -->
+				<xsl:attribute name="class">blank</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>
+		  	</xsl:otherwise>
+		</xsl:choose>
+	</xsl:for-each>
+	<xsl:if test="not (//fact[relation='cell' and argument[1]=$loc])">
+    	<!-- New-style blank space, with no explicit representation in the XML -->
+    	<xsl:attribute name="class">blank</xsl:attribute>
+		<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>
+    </xsl:if>
+  </div>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/chineseCheckers2/chineseCheckers.xsl
+++ b/war/root/games/chineseCheckers2/chineseCheckers.xsl
@@ -1,1 +1,184 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">					#main					{						position:   relative;						width:  <xsl:value-of select="$width"/>px;						height: <xsl:value-of select="$height"/>px;						padding:    10px;						border:     2px solid #b17735;						background: transparent url(&ROOT;/resources/images/chineseCheckers/ccboard.png) repeat top left; 					}							div.teal					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #00ffff;					}					div.red					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ff0000;					}					div.blue					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #0000ff;					}					div.green					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #00ff00;					}					div.yellow					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ffff00;					}					div.magenta					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ff00ff;					}					div.blank					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #cca083;					}					#a1,#i1					{						margin-left: <xsl:value-of select="$width * 0.428571429"/>px;						clear: left;					}					#b1,#h1					{						margin-left: <xsl:value-of select="$width * 0.357142857"/>px;						float: left;						clear: left;					}					#c1,#g1					{						margin-left: 0px;						clear: left;						float: left;					}					#d1,#f1					{						margin-left: <xsl:value-of select="$width * 0.0714285714"/>px;						clear: left;						float: left;					}					#e1					{						margin-left: <xsl:value-of select="$width * 0.142857143"/>px;						clear: left;						float: left;					}      img.piece {      	width: <xsl:value-of select="$width * 0.142857143"/>px;      	height: <xsl:value-of select="$height * 0.113"/>px;           }					    </style>        <div id="main">    	<xsl:call-template name="cell"><xsl:with-param name="loc">a1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">b1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">b2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c7</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g7</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">h1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">h2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">i1</xsl:with-param></xsl:call-template>    </div>   </div>  </xsl:template><xsl:template name="cell">  <xsl:param name="loc" select="a1"/>  <div style="float: left">	<xsl:attribute name="id"><xsl:value-of select="$loc"/></xsl:attribute>	  <xsl:for-each select="//fact[relation='cell' and argument[1]=$loc]">			<xsl:choose>			    <xsl:when test="argument[2]='yellow'">				<xsl:attribute name="class">yellow</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>			</xsl:when>		    <xsl:when test="argument[2]='magenta'">				<xsl:attribute name="class">magenta</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>	 	    <xsl:when test="argument[2]='teal'">				<xsl:attribute name="class">teal</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='green'">				<xsl:attribute name="class">green</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='red'">				<xsl:attribute name="class">red</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='blue'">				<xsl:attribute name="class">blue</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:otherwise>		    	<!-- Old-style blank space, where there's an explicit representation of the blank square -->				<xsl:attribute name="class">blank</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>		  	</xsl:otherwise>		</xsl:choose>	</xsl:for-each>	<xsl:if test="not (//fact[relation='cell' and argument[1]=$loc])">    	<!-- New-style blank space, with no explicit representation in the XML -->    	<xsl:attribute name="class">blank</xsl:attribute>		<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>    </xsl:if>  </div></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+					#main
+					{
+						position:   relative;
+						width:  <xsl:value-of select="$width"/>px;
+						height: <xsl:value-of select="$height"/>px;
+						padding:    10px;
+						border:     2px solid #b17735;
+						background: transparent url(&ROOT;/resources/images/chineseCheckers/ccboard.png) repeat top left; 
+					}		
+					div.teal
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #00ffff;
+					}
+					div.red
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ff0000;
+					}
+					div.blue
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #0000ff;
+					}
+					div.green
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #00ff00;
+					}
+					div.yellow
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ffff00;
+					}
+					div.magenta
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ff00ff;
+					}
+					div.blank
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #cca083;
+					}
+					#a1,#i1
+					{
+						margin-left: <xsl:value-of select="$width * 0.428571429"/>px;
+						clear: left;
+					}
+					#b1,#h1
+					{
+						margin-left: <xsl:value-of select="$width * 0.357142857"/>px;
+						float: left;
+						clear: left;
+					}
+					#c1,#g1
+					{
+						margin-left: 0px;
+						clear: left;
+						float: left;
+					}
+					#d1,#f1
+					{
+						margin-left: <xsl:value-of select="$width * 0.0714285714"/>px;
+						clear: left;
+						float: left;
+					}
+					#e1
+					{
+						margin-left: <xsl:value-of select="$width * 0.142857143"/>px;
+						clear: left;
+						float: left;
+					}
+      img.piece {
+      	width: <xsl:value-of select="$width * 0.142857143"/>px;
+      	height: <xsl:value-of select="$height * 0.113"/>px;     
+      }					
+    </style>
+    
+    <div id="main">
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">a1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">b1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">b2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c7</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g7</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">h1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">h2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">i1</xsl:with-param></xsl:call-template>
+    </div> 
+
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell">
+  <xsl:param name="loc" select="a1"/>
+
+  <div style="float: left">
+	<xsl:attribute name="id"><xsl:value-of select="$loc"/></xsl:attribute>
+	  <xsl:for-each select="//fact[relation='cell' and argument[1]=$loc]">
+			<xsl:choose>
+			    <xsl:when test="argument[2]='yellow'">
+				<xsl:attribute name="class">yellow</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+			</xsl:when>
+		    <xsl:when test="argument[2]='magenta'">
+				<xsl:attribute name="class">magenta</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+	 	    <xsl:when test="argument[2]='teal'">
+				<xsl:attribute name="class">teal</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='green'">
+				<xsl:attribute name="class">green</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='red'">
+				<xsl:attribute name="class">red</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='blue'">
+				<xsl:attribute name="class">blue</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:otherwise>
+		    	<!-- Old-style blank space, where there's an explicit representation of the blank square -->
+				<xsl:attribute name="class">blank</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>
+		  	</xsl:otherwise>
+		</xsl:choose>
+	</xsl:for-each>
+	<xsl:if test="not (//fact[relation='cell' and argument[1]=$loc])">
+    	<!-- New-style blank space, with no explicit representation in the XML -->
+    	<xsl:attribute name="class">blank</xsl:attribute>
+		<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>
+    </xsl:if>
+  </div>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/chineseCheckers3/chineseCheckers.xsl
+++ b/war/root/games/chineseCheckers3/chineseCheckers.xsl
@@ -1,1 +1,184 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">					#main					{						position:   relative;						width:  <xsl:value-of select="$width"/>px;						height: <xsl:value-of select="$height"/>px;						padding:    10px;						border:     2px solid #b17735;						background: transparent url(&ROOT;/resources/images/chineseCheckers/ccboard.png) repeat top left; 					}							div.teal					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #00ffff;					}					div.red					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ff0000;					}					div.blue					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #0000ff;					}					div.green					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #00ff00;					}					div.yellow					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ffff00;					}					div.magenta					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ff00ff;					}					div.blank					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #cca083;					}					#a1,#i1					{						margin-left: <xsl:value-of select="$width * 0.428571429"/>px;						clear: left;					}					#b1,#h1					{						margin-left: <xsl:value-of select="$width * 0.357142857"/>px;						float: left;						clear: left;					}					#c1,#g1					{						margin-left: 0px;						clear: left;						float: left;					}					#d1,#f1					{						margin-left: <xsl:value-of select="$width * 0.0714285714"/>px;						clear: left;						float: left;					}					#e1					{						margin-left: <xsl:value-of select="$width * 0.142857143"/>px;						clear: left;						float: left;					}      img.piece {      	width: <xsl:value-of select="$width * 0.142857143"/>px;      	height: <xsl:value-of select="$height * 0.113"/>px;           }					    </style>        <div id="main">    	<xsl:call-template name="cell"><xsl:with-param name="loc">a1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">b1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">b2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c7</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g7</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">h1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">h2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">i1</xsl:with-param></xsl:call-template>    </div>   </div>  </xsl:template><xsl:template name="cell">  <xsl:param name="loc" select="a1"/>  <div style="float: left">	<xsl:attribute name="id"><xsl:value-of select="$loc"/></xsl:attribute>	  <xsl:for-each select="//fact[relation='cell' and argument[1]=$loc]">			<xsl:choose>			    <xsl:when test="argument[2]='yellow'">				<xsl:attribute name="class">yellow</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>			</xsl:when>		    <xsl:when test="argument[2]='magenta'">				<xsl:attribute name="class">magenta</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>	 	    <xsl:when test="argument[2]='teal'">				<xsl:attribute name="class">teal</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='green'">				<xsl:attribute name="class">green</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='red'">				<xsl:attribute name="class">red</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='blue'">				<xsl:attribute name="class">blue</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:otherwise>		    	<!-- Old-style blank space, where there's an explicit representation of the blank square -->				<xsl:attribute name="class">blank</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>		  	</xsl:otherwise>		</xsl:choose>	</xsl:for-each>	<xsl:if test="not (//fact[relation='cell' and argument[1]=$loc])">    	<!-- New-style blank space, with no explicit representation in the XML -->    	<xsl:attribute name="class">blank</xsl:attribute>		<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>    </xsl:if>  </div></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+					#main
+					{
+						position:   relative;
+						width:  <xsl:value-of select="$width"/>px;
+						height: <xsl:value-of select="$height"/>px;
+						padding:    10px;
+						border:     2px solid #b17735;
+						background: transparent url(&ROOT;/resources/images/chineseCheckers/ccboard.png) repeat top left; 
+					}		
+					div.teal
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #00ffff;
+					}
+					div.red
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ff0000;
+					}
+					div.blue
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #0000ff;
+					}
+					div.green
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #00ff00;
+					}
+					div.yellow
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ffff00;
+					}
+					div.magenta
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ff00ff;
+					}
+					div.blank
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #cca083;
+					}
+					#a1,#i1
+					{
+						margin-left: <xsl:value-of select="$width * 0.428571429"/>px;
+						clear: left;
+					}
+					#b1,#h1
+					{
+						margin-left: <xsl:value-of select="$width * 0.357142857"/>px;
+						float: left;
+						clear: left;
+					}
+					#c1,#g1
+					{
+						margin-left: 0px;
+						clear: left;
+						float: left;
+					}
+					#d1,#f1
+					{
+						margin-left: <xsl:value-of select="$width * 0.0714285714"/>px;
+						clear: left;
+						float: left;
+					}
+					#e1
+					{
+						margin-left: <xsl:value-of select="$width * 0.142857143"/>px;
+						clear: left;
+						float: left;
+					}
+      img.piece {
+      	width: <xsl:value-of select="$width * 0.142857143"/>px;
+      	height: <xsl:value-of select="$height * 0.113"/>px;     
+      }					
+    </style>
+    
+    <div id="main">
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">a1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">b1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">b2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c7</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g7</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">h1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">h2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">i1</xsl:with-param></xsl:call-template>
+    </div> 
+
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell">
+  <xsl:param name="loc" select="a1"/>
+
+  <div style="float: left">
+	<xsl:attribute name="id"><xsl:value-of select="$loc"/></xsl:attribute>
+	  <xsl:for-each select="//fact[relation='cell' and argument[1]=$loc]">
+			<xsl:choose>
+			    <xsl:when test="argument[2]='yellow'">
+				<xsl:attribute name="class">yellow</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+			</xsl:when>
+		    <xsl:when test="argument[2]='magenta'">
+				<xsl:attribute name="class">magenta</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+	 	    <xsl:when test="argument[2]='teal'">
+				<xsl:attribute name="class">teal</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='green'">
+				<xsl:attribute name="class">green</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='red'">
+				<xsl:attribute name="class">red</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='blue'">
+				<xsl:attribute name="class">blue</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:otherwise>
+		    	<!-- Old-style blank space, where there's an explicit representation of the blank square -->
+				<xsl:attribute name="class">blank</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>
+		  	</xsl:otherwise>
+		</xsl:choose>
+	</xsl:for-each>
+	<xsl:if test="not (//fact[relation='cell' and argument[1]=$loc])">
+    	<!-- New-style blank space, with no explicit representation in the XML -->
+    	<xsl:attribute name="class">blank</xsl:attribute>
+		<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>
+    </xsl:if>
+  </div>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/chineseCheckers4/chineseCheckers.xsl
+++ b/war/root/games/chineseCheckers4/chineseCheckers.xsl
@@ -1,1 +1,184 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">					#main					{						position:   relative;						width:  <xsl:value-of select="$width"/>px;						height: <xsl:value-of select="$height"/>px;						padding:    10px;						border:     2px solid #b17735;						background: transparent url(&ROOT;/resources/images/chineseCheckers/ccboard.png) repeat top left; 					}							div.teal					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #00ffff;					}					div.red					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ff0000;					}					div.blue					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #0000ff;					}					div.green					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #00ff00;					}					div.yellow					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ffff00;					}					div.magenta					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ff00ff;					}					div.blank					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #cca083;					}					#a1,#i1					{						margin-left: <xsl:value-of select="$width * 0.428571429"/>px;						clear: left;					}					#b1,#h1					{						margin-left: <xsl:value-of select="$width * 0.357142857"/>px;						float: left;						clear: left;					}					#c1,#g1					{						margin-left: 0px;						clear: left;						float: left;					}					#d1,#f1					{						margin-left: <xsl:value-of select="$width * 0.0714285714"/>px;						clear: left;						float: left;					}					#e1					{						margin-left: <xsl:value-of select="$width * 0.142857143"/>px;						clear: left;						float: left;					}      img.piece {      	width: <xsl:value-of select="$width * 0.142857143"/>px;      	height: <xsl:value-of select="$height * 0.113"/>px;           }					    </style>        <div id="main">    	<xsl:call-template name="cell"><xsl:with-param name="loc">a1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">b1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">b2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c7</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g7</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">h1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">h2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">i1</xsl:with-param></xsl:call-template>    </div>   </div>  </xsl:template><xsl:template name="cell">  <xsl:param name="loc" select="a1"/>  <div style="float: left">	<xsl:attribute name="id"><xsl:value-of select="$loc"/></xsl:attribute>	  <xsl:for-each select="//fact[relation='cell' and argument[1]=$loc]">			<xsl:choose>			    <xsl:when test="argument[2]='yellow'">				<xsl:attribute name="class">yellow</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>			</xsl:when>		    <xsl:when test="argument[2]='magenta'">				<xsl:attribute name="class">magenta</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>	 	    <xsl:when test="argument[2]='teal'">				<xsl:attribute name="class">teal</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='green'">				<xsl:attribute name="class">green</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='red'">				<xsl:attribute name="class">red</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='blue'">				<xsl:attribute name="class">blue</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:otherwise>		    	<!-- Old-style blank space, where there's an explicit representation of the blank square -->				<xsl:attribute name="class">blank</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>		  	</xsl:otherwise>		</xsl:choose>	</xsl:for-each>	<xsl:if test="not (//fact[relation='cell' and argument[1]=$loc])">    	<!-- New-style blank space, with no explicit representation in the XML -->    	<xsl:attribute name="class">blank</xsl:attribute>		<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>    </xsl:if>  </div></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+					#main
+					{
+						position:   relative;
+						width:  <xsl:value-of select="$width"/>px;
+						height: <xsl:value-of select="$height"/>px;
+						padding:    10px;
+						border:     2px solid #b17735;
+						background: transparent url(&ROOT;/resources/images/chineseCheckers/ccboard.png) repeat top left; 
+					}		
+					div.teal
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #00ffff;
+					}
+					div.red
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ff0000;
+					}
+					div.blue
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #0000ff;
+					}
+					div.green
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #00ff00;
+					}
+					div.yellow
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ffff00;
+					}
+					div.magenta
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ff00ff;
+					}
+					div.blank
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #cca083;
+					}
+					#a1,#i1
+					{
+						margin-left: <xsl:value-of select="$width * 0.428571429"/>px;
+						clear: left;
+					}
+					#b1,#h1
+					{
+						margin-left: <xsl:value-of select="$width * 0.357142857"/>px;
+						float: left;
+						clear: left;
+					}
+					#c1,#g1
+					{
+						margin-left: 0px;
+						clear: left;
+						float: left;
+					}
+					#d1,#f1
+					{
+						margin-left: <xsl:value-of select="$width * 0.0714285714"/>px;
+						clear: left;
+						float: left;
+					}
+					#e1
+					{
+						margin-left: <xsl:value-of select="$width * 0.142857143"/>px;
+						clear: left;
+						float: left;
+					}
+      img.piece {
+      	width: <xsl:value-of select="$width * 0.142857143"/>px;
+      	height: <xsl:value-of select="$height * 0.113"/>px;     
+      }					
+    </style>
+    
+    <div id="main">
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">a1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">b1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">b2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c7</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g7</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">h1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">h2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">i1</xsl:with-param></xsl:call-template>
+    </div> 
+
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell">
+  <xsl:param name="loc" select="a1"/>
+
+  <div style="float: left">
+	<xsl:attribute name="id"><xsl:value-of select="$loc"/></xsl:attribute>
+	  <xsl:for-each select="//fact[relation='cell' and argument[1]=$loc]">
+			<xsl:choose>
+			    <xsl:when test="argument[2]='yellow'">
+				<xsl:attribute name="class">yellow</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+			</xsl:when>
+		    <xsl:when test="argument[2]='magenta'">
+				<xsl:attribute name="class">magenta</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+	 	    <xsl:when test="argument[2]='teal'">
+				<xsl:attribute name="class">teal</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='green'">
+				<xsl:attribute name="class">green</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='red'">
+				<xsl:attribute name="class">red</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='blue'">
+				<xsl:attribute name="class">blue</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:otherwise>
+		    	<!-- Old-style blank space, where there's an explicit representation of the blank square -->
+				<xsl:attribute name="class">blank</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>
+		  	</xsl:otherwise>
+		</xsl:choose>
+	</xsl:for-each>
+	<xsl:if test="not (//fact[relation='cell' and argument[1]=$loc])">
+    	<!-- New-style blank space, with no explicit representation in the XML -->
+    	<xsl:attribute name="class">blank</xsl:attribute>
+		<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>
+    </xsl:if>
+  </div>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/chineseCheckers6/chineseCheckers.xsl
+++ b/war/root/games/chineseCheckers6/chineseCheckers.xsl
@@ -1,1 +1,184 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">					#main					{						position:   relative;						width:  <xsl:value-of select="$width"/>px;						height: <xsl:value-of select="$height"/>px;						padding:    10px;						border:     2px solid #b17735;						background: transparent url(&ROOT;/resources/images/chineseCheckers/ccboard.png) repeat top left; 					}							div.teal					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #00ffff;					}					div.red					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ff0000;					}					div.blue					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #0000ff;					}					div.green					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #00ff00;					}					div.yellow					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ffff00;					}					div.magenta					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ff00ff;					}					div.blank					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #cca083;					}					#a1,#i1					{						margin-left: <xsl:value-of select="$width * 0.428571429"/>px;						clear: left;					}					#b1,#h1					{						margin-left: <xsl:value-of select="$width * 0.357142857"/>px;						float: left;						clear: left;					}					#c1,#g1					{						margin-left: 0px;						clear: left;						float: left;					}					#d1,#f1					{						margin-left: <xsl:value-of select="$width * 0.0714285714"/>px;						clear: left;						float: left;					}					#e1					{						margin-left: <xsl:value-of select="$width * 0.142857143"/>px;						clear: left;						float: left;					}      img.piece {      	width: <xsl:value-of select="$width * 0.142857143"/>px;      	height: <xsl:value-of select="$height * 0.113"/>px;           }					    </style>        <div id="main">    	<xsl:call-template name="cell"><xsl:with-param name="loc">a1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">b1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">b2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c7</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g7</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">h1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">h2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">i1</xsl:with-param></xsl:call-template>    </div>   </div>  </xsl:template><xsl:template name="cell">  <xsl:param name="loc" select="a1"/>  <div style="float: left">	<xsl:attribute name="id"><xsl:value-of select="$loc"/></xsl:attribute>	  <xsl:for-each select="//fact[relation='cell' and argument[1]=$loc]">			<xsl:choose>			    <xsl:when test="argument[2]='yellow'">				<xsl:attribute name="class">yellow</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>			</xsl:when>		    <xsl:when test="argument[2]='magenta'">				<xsl:attribute name="class">magenta</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>	 	    <xsl:when test="argument[2]='teal'">				<xsl:attribute name="class">teal</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='green'">				<xsl:attribute name="class">green</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='red'">				<xsl:attribute name="class">red</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='blue'">				<xsl:attribute name="class">blue</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:otherwise>		    	<!-- Old-style blank space, where there's an explicit representation of the blank square -->				<xsl:attribute name="class">blank</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>		  	</xsl:otherwise>		</xsl:choose>	</xsl:for-each>	<xsl:if test="not (//fact[relation='cell' and argument[1]=$loc])">    	<!-- New-style blank space, with no explicit representation in the XML -->    	<xsl:attribute name="class">blank</xsl:attribute>		<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>    </xsl:if>  </div></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+					#main
+					{
+						position:   relative;
+						width:  <xsl:value-of select="$width"/>px;
+						height: <xsl:value-of select="$height"/>px;
+						padding:    10px;
+						border:     2px solid #b17735;
+						background: transparent url(&ROOT;/resources/images/chineseCheckers/ccboard.png) repeat top left; 
+					}		
+					div.teal
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #00ffff;
+					}
+					div.red
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ff0000;
+					}
+					div.blue
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #0000ff;
+					}
+					div.green
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #00ff00;
+					}
+					div.yellow
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ffff00;
+					}
+					div.magenta
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ff00ff;
+					}
+					div.blank
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #cca083;
+					}
+					#a1,#i1
+					{
+						margin-left: <xsl:value-of select="$width * 0.428571429"/>px;
+						clear: left;
+					}
+					#b1,#h1
+					{
+						margin-left: <xsl:value-of select="$width * 0.357142857"/>px;
+						float: left;
+						clear: left;
+					}
+					#c1,#g1
+					{
+						margin-left: 0px;
+						clear: left;
+						float: left;
+					}
+					#d1,#f1
+					{
+						margin-left: <xsl:value-of select="$width * 0.0714285714"/>px;
+						clear: left;
+						float: left;
+					}
+					#e1
+					{
+						margin-left: <xsl:value-of select="$width * 0.142857143"/>px;
+						clear: left;
+						float: left;
+					}
+      img.piece {
+      	width: <xsl:value-of select="$width * 0.142857143"/>px;
+      	height: <xsl:value-of select="$height * 0.113"/>px;     
+      }					
+    </style>
+    
+    <div id="main">
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">a1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">b1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">b2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c7</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g7</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">h1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">h2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">i1</xsl:with-param></xsl:call-template>
+    </div> 
+
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell">
+  <xsl:param name="loc" select="a1"/>
+
+  <div style="float: left">
+	<xsl:attribute name="id"><xsl:value-of select="$loc"/></xsl:attribute>
+	  <xsl:for-each select="//fact[relation='cell' and argument[1]=$loc]">
+			<xsl:choose>
+			    <xsl:when test="argument[2]='yellow'">
+				<xsl:attribute name="class">yellow</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+			</xsl:when>
+		    <xsl:when test="argument[2]='magenta'">
+				<xsl:attribute name="class">magenta</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+	 	    <xsl:when test="argument[2]='teal'">
+				<xsl:attribute name="class">teal</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='green'">
+				<xsl:attribute name="class">green</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='red'">
+				<xsl:attribute name="class">red</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='blue'">
+				<xsl:attribute name="class">blue</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:otherwise>
+		    	<!-- Old-style blank space, where there's an explicit representation of the blank square -->
+				<xsl:attribute name="class">blank</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>
+		  	</xsl:otherwise>
+		</xsl:choose>
+	</xsl:for-each>
+	<xsl:if test="not (//fact[relation='cell' and argument[1]=$loc])">
+    	<!-- New-style blank space, with no explicit representation in the XML -->
+    	<xsl:attribute name="class">blank</xsl:attribute>
+		<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>
+    </xsl:if>
+  </div>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/chinook/chinook.xsl
+++ b/war/root/games/chinook/chinook.xsl
@@ -1,1 +1,116 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>  <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col_char"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="($row + $col) mod 2 = 0">    <xsl:attribute name="style">background-color: #555555</xsl:attribute>    </xsl:if>  <center>  <xsl:if test="//fact[relation='oddcell' and argument[1]=$col_char and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='oddcell' and argument[1]=$col_char and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>    <xsl:if test="//fact[relation='evencell' and argument[1]=$col_char and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='evencell' and argument[1]=$col_char and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col_char"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+  <xsl:if test="($row + $col) mod 2 = 0">
+    <xsl:attribute name="style">background-color: #555555</xsl:attribute>  
+  </xsl:if>
+
+  <center>
+  <xsl:if test="//fact[relation='oddcell' and argument[1]=$col_char and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='oddcell' and argument[1]=$col_char and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  
+  <xsl:if test="//fact[relation='evencell' and argument[1]=$col_char and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='evencell' and argument[1]=$col_char and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/connect5/connect5.xsl
+++ b/war/root/games/connect5/connect5.xsl
@@ -1,1 +1,107 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        font-size: <xsl:value-of select="$width * 0.6 * 0.125"/>px;        text-align: center;        font-weight: bold;        align: center;      }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>  <xsl:param name="row_char" select="translate(translate(translate(translate(translate(translate(translate(translate($row,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>  <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col_char"/>    <xsl:value-of select="$row_char"/>  </xsl:attribute>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row_char and argument[3]='x']">X</xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row_char and argument[3]='o']"><font color="#999999">O</font></xsl:if>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.125"/>px;
+        text-align: center;
+        font-weight: bold;
+        align: center;
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>
+  <xsl:param name="row_char" select="translate(translate(translate(translate(translate(translate(translate(translate($row,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col_char"/>
+    <xsl:value-of select="$row_char"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row_char and argument[3]='x']">X</xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row_char and argument[3]='o']"><font color="#999999">O</font></xsl:if>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/connectFour/connectFour.xsl
+++ b/war/root/games/connectFour/connectFour.xsl
@@ -1,1 +1,106 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="6"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="7 - $row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="6"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="7 - $row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/connectFourLarge/connectFourLarge.xsl
+++ b/war/root/games/connectFourLarge/connectFourLarge.xsl
@@ -1,1 +1,106 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.083"/>px;        height: <xsl:value-of select="$height * 0.083"/>px;        border: 2px solid #000;        background-color: #CCCCCC;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.083"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.083"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="12"/>      <xsl:with-param name="rows" select="9"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="10 - $row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.083"/>px;
+        height: <xsl:value-of select="$height * 0.083"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.083"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.083"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="12"/>
+      <xsl:with-param name="rows" select="9"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="10 - $row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/connectFourLarger/connectFourLarger.xsl
+++ b/war/root/games/connectFourLarger/connectFourLarger.xsl
@@ -1,1 +1,106 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.05"/>px;        height: <xsl:value-of select="$height * 0.05"/>px;        border: 2px solid #000;        background-color: #CCCCCC;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.05"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.05"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="20"/>      <xsl:with-param name="rows" select="20"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="21 - $row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.05"/>px;
+        height: <xsl:value-of select="$height * 0.05"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.05"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.05"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="20"/>
+      <xsl:with-param name="rows" select="20"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="21 - $row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/connectFourSimultaneous/connectFourSimultaneous.xsl
+++ b/war/root/games/connectFourSimultaneous/connectFourSimultaneous.xsl
@@ -1,1 +1,122 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.083"/>px;        height: <xsl:value-of select="$height * 0.083"/>px;        border: 2px solid #000;        background-color: #CCCCCC;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.083"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.083"/>px;              }    </style>        <!-- Draw Boards -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="6"/>      <xsl:with-param name="board" select="1"/>    </xsl:call-template>		        <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="6"/>      <xsl:with-param name="board" select="2"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <xsl:param name="board" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>    <xsl:value-of select="$board"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]=$board and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]=$board and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>  <xsl:param name="board" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="7 - $row"/>    <xsl:with-param name="col" select="$col"/>    <xsl:with-param name="board" select="$board"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>      <xsl:with-param name="board" select="$board"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="board" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="board" select="$board"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>      <xsl:with-param name="board" select="$board"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <xsl:param name="board" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="board" select="$board"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.083"/>px;
+        height: <xsl:value-of select="$height * 0.083"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.083"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.083"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Boards -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="6"/>
+      <xsl:with-param name="board" select="1"/>
+    </xsl:call-template>		    
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="6"/>
+      <xsl:with-param name="board" select="2"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  <xsl:param name="board" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+    <xsl:value-of select="$board"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]=$board and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]=$board and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  <xsl:param name="board" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="7 - $row"/>
+    <xsl:with-param name="col" select="$col"/>
+    <xsl:with-param name="board" select="$board"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+      <xsl:with-param name="board" select="$board"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="board" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="board" select="$board"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+      <xsl:with-param name="board" select="$board"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+  <xsl:param name="board" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="board" select="$board"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/connectFourSuicide/connectFourSuicide.xsl
+++ b/war/root/games/connectFourSuicide/connectFourSuicide.xsl
@@ -1,1 +1,106 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="6"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="7 - $row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="6"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="7 - $row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/connectFour_9x6/connectFour_9x6.xsl
+++ b/war/root/games/connectFour_9x6/connectFour_9x6.xsl
@@ -1,1 +1,106 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.111"/>px;        height: <xsl:value-of select="$height * 0.111"/>px;        border: 2px solid #000;        background-color: #CCCCCC;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.111"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.111"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="9"/>      <xsl:with-param name="rows" select="6"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="7 - $row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.111"/>px;
+        height: <xsl:value-of select="$height * 0.111"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.111"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.111"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="9"/>
+      <xsl:with-param name="rows" select="6"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="7 - $row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/eightPuzzle/eightPuzzle.xsl
+++ b/war/root/games/eightPuzzle/eightPuzzle.xsl
@@ -1,1 +1,113 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.333"/>px;        height: <xsl:value-of select="$height * 0.333"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        valign: middle;        font-size: <xsl:value-of select="$width * 0.6 * 0.333"/>px;        text-align: center;        font-weight: bold;        align: center;              }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="3"/>      <xsl:with-param name="rows" select="3"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>        <xsl:value-of select="$col"/>       <xsl:value-of select="$row"/>   </xsl:attribute>  <xsl:choose>    <xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1']"> 1 </xsl:when>  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2']"> 2 </xsl:when>  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3']"> 3 </xsl:when>  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4']"> 4 </xsl:when>  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='5']"> 5 </xsl:when>  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='6']"> 6 </xsl:when>  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='7']"> 7 </xsl:when>  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='8']"> 8 </xsl:when>  	  </xsl:choose>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.333"/>px;
+        height: <xsl:value-of select="$height * 0.333"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        valign: middle;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.333"/>px;
+        text-align: center;
+        font-weight: bold;
+        align: center;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="3"/>
+      <xsl:with-param name="rows" select="3"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>    
+    <xsl:value-of select="$col"/>   
+    <xsl:value-of select="$row"/> 
+  </xsl:attribute>
+
+  <xsl:choose>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1']"> 1 </xsl:when>
+  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2']"> 2 </xsl:when>
+  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3']"> 3 </xsl:when>
+  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4']"> 4 </xsl:when>
+  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='5']"> 5 </xsl:when>
+  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='6']"> 6 </xsl:when>
+  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='7']"> 7 </xsl:when>
+  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='8']"> 8 </xsl:when>  	
+  </xsl:choose>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/escortLatch/escortLatch.xsl
+++ b/war/root/games/escortLatch/escortLatch.xsl
@@ -1,1 +1,112 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>    <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col_char"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wk']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bk']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col_char"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wk']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bk']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/ghostMaze2p/ghostMaze2p.xsl
+++ b/war/root/games/ghostMaze2p/ghostMaze2p.xsl
@@ -1,1 +1,126 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: none;        background-color: #CCCCCC;      }      table.board {        background-color: #000000;        border-collapse: collapse;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='exit']">    <xsl:attribute name="style">background-color: #FB0</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='slime']">    <xsl:attribute name="style">background-color: #0F0</xsl:attribute>  </xsl:if>    <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">    <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px;</xsl:attribute>  </xsl:if>    <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">    <xsl:attribute name="style">border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">    <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">      <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px; border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>    </xsl:if>        </xsl:if>  <center>  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='explorer']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='ghost']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: none;
+        background-color: #CCCCCC;
+      }
+      table.board {
+        background-color: #000000;
+        border-collapse: collapse;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='exit']">
+    <xsl:attribute name="style">background-color: #FB0</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='slime']">
+    <xsl:attribute name="style">background-color: #0F0</xsl:attribute>
+  </xsl:if>
+  
+  <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">
+    <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px;</xsl:attribute>
+  </xsl:if>  
+  <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">
+    <xsl:attribute name="style">border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">
+    <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">
+      <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px; border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>
+    </xsl:if>      
+  </xsl:if>
+
+  <center>
+  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='explorer']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='ghost']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/god/god.xsl
+++ b/war/root/games/god/god.xsl
@@ -1,1 +1,108 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.2"/>px;        height: <xsl:value-of select="$height * 0.2"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        font-size: <xsl:value-of select="$width * 0.6 * 0.2"/>px;        text-align: center;        font-weight: bold;        align: center;      }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="5"/>      <xsl:with-param name="rows" select="5"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='b']">    <xsl:attribute name="style">background-color: #000</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='o']">    <xsl:attribute name="style">background-color: #BBB</xsl:attribute>  </xsl:if>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.2"/>px;
+        height: <xsl:value-of select="$height * 0.2"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.2"/>px;
+        text-align: center;
+        font-weight: bold;
+        align: center;
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="5"/>
+      <xsl:with-param name="rows" select="5"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+  
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='b']">
+    <xsl:attribute name="style">background-color: #000</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='o']">
+    <xsl:attribute name="style">background-color: #BBB</xsl:attribute>
+  </xsl:if>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/knightThrough/knightThrough.xsl
+++ b/war/root/games/knightThrough/knightThrough.xsl
@@ -1,1 +1,108 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/knightfight/knightfight.xsl
+++ b/war/root/games/knightfight/knightfight.xsl
@@ -1,1 +1,107 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.1"/>px;        height: <xsl:value-of select="$height * 0.1"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;              }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.1"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.1"/>px;              }          </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="10"/>      <xsl:with-param name="rows" select="10"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='arrow']"> <xsl:attribute name="style">background-color: #000</xsl:attribute> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>      </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.1"/>px;
+        height: <xsl:value-of select="$height * 0.1"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.1"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.1"/>px;        
+      }      
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="10"/>
+      <xsl:with-param name="rows" select="10"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='arrow']"> <xsl:attribute name="style">background-color: #000</xsl:attribute> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='white']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='black']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>  
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/knightsTour/knightsTour.xsl
+++ b/war/root/games/knightsTour/knightsTour.xsl
@@ -1,1 +1,109 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.167"/>px;        height: <xsl:value-of select="$height * 0.167"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.167"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.167"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="6"/>      <xsl:with-param name="rows" select="5"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>        <xsl:value-of select="$col"/>       <xsl:value-of select="$row"/>   </xsl:attribute>    <xsl:choose>    <xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='hole']"> <xsl:attribute name="style">background-color: #000</xsl:attribute> </xsl:when>  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='knight']"> <center><img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/></center> </xsl:when>  	  </xsl:choose>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.167"/>px;
+        height: <xsl:value-of select="$height * 0.167"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.167"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.167"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="6"/>
+      <xsl:with-param name="rows" select="5"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>    
+    <xsl:value-of select="$col"/>   
+    <xsl:value-of select="$row"/> 
+  </xsl:attribute>
+
+  
+  <xsl:choose>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='hole']"> <xsl:attribute name="style">background-color: #000</xsl:attribute> </xsl:when>
+  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='knight']"> <center><img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/></center> </xsl:when>  	
+  </xsl:choose>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/knightsTourLarge/knightsTourLarge.xsl
+++ b/war/root/games/knightsTourLarge/knightsTourLarge.xsl
@@ -1,1 +1,109 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.111"/>px;        height: <xsl:value-of select="$height * 0.111"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.111"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.111"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="9"/>      <xsl:with-param name="rows" select="9"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>        <xsl:value-of select="$col"/>       <xsl:value-of select="$row"/>   </xsl:attribute>    <xsl:choose>    <xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='hole']"> <xsl:attribute name="style">background-color: #000</xsl:attribute> </xsl:when>  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='knight']"> <center><img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/></center> </xsl:when>  	  </xsl:choose>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.111"/>px;
+        height: <xsl:value-of select="$height * 0.111"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.111"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.111"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="9"/>
+      <xsl:with-param name="rows" select="9"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>    
+    <xsl:value-of select="$col"/>   
+    <xsl:value-of select="$row"/> 
+  </xsl:attribute>
+
+  
+  <xsl:choose>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='hole']"> <xsl:attribute name="style">background-color: #000</xsl:attribute> </xsl:when>
+  	<xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='knight']"> <center><img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/></center> </xsl:when>  	
+  </xsl:choose>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/lightsOn/lightsOn.xsl
+++ b/war/root/games/lightsOn/lightsOn.xsl
@@ -1,1 +1,111 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.5"/>px;        height: <xsl:value-of select="$height * 0.5"/>px;        border: 1px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;              }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="2"/>      <xsl:with-param name="rows" select="2"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">    <xsl:attribute name="id">      <xsl:value-of select="'cell_'"/>      <xsl:value-of select="$col"/>      <xsl:value-of select="$row"/>    </xsl:attribute>        <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1']">      <xsl:attribute name="style">background-color: #600</xsl:attribute>                      </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2']">      <xsl:attribute name="style">background-color: #660</xsl:attribute>    </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3']">      <xsl:attribute name="style">background-color: #690</xsl:attribute>    </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4']">      <xsl:attribute name="style">background-color: #6F0</xsl:attribute>    </xsl:if>  </td></xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.5"/>px;
+        height: <xsl:value-of select="$height * 0.5"/>px;
+        border: 1px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="2"/>
+      <xsl:with-param name="rows" select="2"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+    <xsl:attribute name="id">
+      <xsl:value-of select="'cell_'"/>
+      <xsl:value-of select="$col"/>
+      <xsl:value-of select="$row"/>
+    </xsl:attribute>
+    
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1']">
+      <xsl:attribute name="style">background-color: #600</xsl:attribute>                  
+    </xsl:if>
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2']">
+      <xsl:attribute name="style">background-color: #660</xsl:attribute>
+    </xsl:if>
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3']">
+      <xsl:attribute name="style">background-color: #690</xsl:attribute>
+    </xsl:if>
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4']">
+      <xsl:attribute name="style">background-color: #6F0</xsl:attribute>
+    </xsl:if>
+  </td>
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/lightsOnParallel/lightsOnParallel.xsl
+++ b/war/root/games/lightsOnParallel/lightsOnParallel.xsl
@@ -1,1 +1,111 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.25"/>px;        height: <xsl:value-of select="$height * 0.25"/>px;        border: 1px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;              }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="4"/>      <xsl:with-param name="rows" select="4"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">    <xsl:attribute name="id">      <xsl:value-of select="'cell_'"/>      <xsl:value-of select="$col"/>      <xsl:value-of select="$row"/>    </xsl:attribute>        <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1']">      <xsl:attribute name="style">background-color: #600</xsl:attribute>                      </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2']">      <xsl:attribute name="style">background-color: #660</xsl:attribute>    </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3']">      <xsl:attribute name="style">background-color: #690</xsl:attribute>    </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4']">      <xsl:attribute name="style">background-color: #6F0</xsl:attribute>    </xsl:if>  </td></xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.25"/>px;
+        height: <xsl:value-of select="$height * 0.25"/>px;
+        border: 1px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="4"/>
+      <xsl:with-param name="rows" select="4"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+    <xsl:attribute name="id">
+      <xsl:value-of select="'cell_'"/>
+      <xsl:value-of select="$col"/>
+      <xsl:value-of select="$row"/>
+    </xsl:attribute>
+    
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1']">
+      <xsl:attribute name="style">background-color: #600</xsl:attribute>                  
+    </xsl:if>
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2']">
+      <xsl:attribute name="style">background-color: #660</xsl:attribute>
+    </xsl:if>
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3']">
+      <xsl:attribute name="style">background-color: #690</xsl:attribute>
+    </xsl:if>
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4']">
+      <xsl:attribute name="style">background-color: #6F0</xsl:attribute>
+    </xsl:if>
+  </td>
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/lightsOnSimul4/lightsOnSimul4.xsl
+++ b/war/root/games/lightsOnSimul4/lightsOnSimul4.xsl
@@ -1,1 +1,111 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.25"/>px;        height: <xsl:value-of select="$height * 0.25"/>px;        border: 1px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;              }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="4"/>      <xsl:with-param name="rows" select="4"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">    <xsl:attribute name="id">      <xsl:value-of select="'cell_'"/>      <xsl:value-of select="$col"/>      <xsl:value-of select="$row"/>    </xsl:attribute>        <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1']">      <xsl:attribute name="style">background-color: #600</xsl:attribute>                      </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2']">      <xsl:attribute name="style">background-color: #660</xsl:attribute>    </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3']">      <xsl:attribute name="style">background-color: #690</xsl:attribute>    </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4']">      <xsl:attribute name="style">background-color: #6F0</xsl:attribute>    </xsl:if>  </td></xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.25"/>px;
+        height: <xsl:value-of select="$height * 0.25"/>px;
+        border: 1px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="4"/>
+      <xsl:with-param name="rows" select="4"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+    <xsl:attribute name="id">
+      <xsl:value-of select="'cell_'"/>
+      <xsl:value-of select="$col"/>
+      <xsl:value-of select="$row"/>
+    </xsl:attribute>
+    
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1']">
+      <xsl:attribute name="style">background-color: #600</xsl:attribute>                  
+    </xsl:if>
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2']">
+      <xsl:attribute name="style">background-color: #660</xsl:attribute>
+    </xsl:if>
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3']">
+      <xsl:attribute name="style">background-color: #690</xsl:attribute>
+    </xsl:if>
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4']">
+      <xsl:attribute name="style">background-color: #6F0</xsl:attribute>
+    </xsl:if>
+  </td>
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/lightsOnSimultaneous/lightsOnSimultaneous.xsl
+++ b/war/root/games/lightsOnSimultaneous/lightsOnSimultaneous.xsl
@@ -1,1 +1,111 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.25"/>px;        height: <xsl:value-of select="$height * 0.25"/>px;        border: 1px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;              }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="4"/>      <xsl:with-param name="rows" select="4"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">    <xsl:attribute name="id">      <xsl:value-of select="'cell_'"/>      <xsl:value-of select="$col"/>      <xsl:value-of select="$row"/>    </xsl:attribute>        <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1']">      <xsl:attribute name="style">background-color: #600</xsl:attribute>                      </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2']">      <xsl:attribute name="style">background-color: #660</xsl:attribute>    </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3']">      <xsl:attribute name="style">background-color: #690</xsl:attribute>    </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4']">      <xsl:attribute name="style">background-color: #6F0</xsl:attribute>    </xsl:if>  </td></xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.25"/>px;
+        height: <xsl:value-of select="$height * 0.25"/>px;
+        border: 1px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="4"/>
+      <xsl:with-param name="rows" select="4"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+    <xsl:attribute name="id">
+      <xsl:value-of select="'cell_'"/>
+      <xsl:value-of select="$col"/>
+      <xsl:value-of select="$row"/>
+    </xsl:attribute>
+    
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1']">
+      <xsl:attribute name="style">background-color: #600</xsl:attribute>                  
+    </xsl:if>
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2']">
+      <xsl:attribute name="style">background-color: #660</xsl:attribute>
+    </xsl:if>
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3']">
+      <xsl:attribute name="style">background-color: #690</xsl:attribute>
+    </xsl:if>
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4']">
+      <xsl:attribute name="style">background-color: #6F0</xsl:attribute>
+    </xsl:if>
+  </td>
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/lightsOut/lightsOut.xsl
+++ b/war/root/games/lightsOut/lightsOut.xsl
@@ -1,1 +1,107 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.2"/>px;        height: <xsl:value-of select="$height * 0.2"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.2"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.2"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="5"/>      <xsl:with-param name="rows" select="5"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$row"/>    <xsl:value-of select="$col"/>      </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='light']"> <img class="piece" src="&ROOT;/resources/images/discs/yellow.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.2"/>px;
+        height: <xsl:value-of select="$height * 0.2"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.2"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.2"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="5"/>
+      <xsl:with-param name="rows" select="5"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$row"/>
+    <xsl:value-of select="$col"/>    
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and argument[3]='light']"> <img class="piece" src="&ROOT;/resources/images/discs/yellow.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/max_knights/chess.xsl
+++ b/war/root/games/max_knights/chess.xsl
@@ -1,1 +1,120 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>  <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col_char"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wr']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wk']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wq']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wb']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='br']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bk']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bq']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bb']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col_char"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wr']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wk']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wq']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wb']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='br']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bk']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bq']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bb']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/maze/maze.xsl
+++ b/war/root/games/maze/maze.xsl
@@ -1,1 +1,118 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.5"/>px;        height: <xsl:value-of select="$height * 0.5"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        font-size: <xsl:value-of select="$width * 0.6 * 0.5"/>px;        text-align: center;        font-weight: bold;        align: center;              }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="2"/>      <xsl:with-param name="rows" select="2"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>    <xsl:if test="$row=1 and $col=1">      <xsl:if test="//fact[relation='cell']/argument='a'">R</xsl:if>      <xsl:if test="//fact[relation='gold']/argument='a'">G</xsl:if>	    </xsl:if>    <xsl:if test="$row=1 and $col=2">      <xsl:if test="//fact[relation='cell']/argument='b'">R</xsl:if>      <xsl:if test="//fact[relation='gold']/argument='b'">G</xsl:if>	    </xsl:if>    <xsl:if test="$row=2 and $col=1">      <xsl:if test="//fact[relation='cell']/argument='d'">R</xsl:if>      <xsl:if test="//fact[relation='gold']/argument='d'">G</xsl:if>	    </xsl:if>    <xsl:if test="$row=2 and $col=2">      <xsl:if test="//fact[relation='cell']/argument='c'">R</xsl:if>      <xsl:if test="//fact[relation='gold']/argument='c'">G</xsl:if>	    </xsl:if>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.5"/>px;
+        height: <xsl:value-of select="$height * 0.5"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.5"/>px;
+        text-align: center;
+        font-weight: bold;
+        align: center;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="2"/>
+      <xsl:with-param name="rows" select="2"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+    <xsl:if test="$row=1 and $col=1">
+      <xsl:if test="//fact[relation='cell']/argument='a'">R</xsl:if>
+      <xsl:if test="//fact[relation='gold']/argument='a'">G</xsl:if>	
+    </xsl:if>
+    <xsl:if test="$row=1 and $col=2">
+      <xsl:if test="//fact[relation='cell']/argument='b'">R</xsl:if>
+      <xsl:if test="//fact[relation='gold']/argument='b'">G</xsl:if>	
+    </xsl:if>
+    <xsl:if test="$row=2 and $col=1">
+      <xsl:if test="//fact[relation='cell']/argument='d'">R</xsl:if>
+      <xsl:if test="//fact[relation='gold']/argument='d'">G</xsl:if>	
+    </xsl:if>
+    <xsl:if test="$row=2 and $col=2">
+      <xsl:if test="//fact[relation='cell']/argument='c'">R</xsl:if>
+      <xsl:if test="//fact[relation='gold']/argument='c'">G</xsl:if>	
+    </xsl:if>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/nineBoardTicTacToe/nineBoardTicTacToe.xsl
+++ b/war/root/games/nineBoardTicTacToe/nineBoardTicTacToe.xsl
@@ -1,1 +1,129 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.111"/>px;        height: <xsl:value-of select="$height * 0.111"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        font-size: <xsl:value-of select="$width * 0.6 * 0.111"/>px;        text-align: center;        font-weight: bold;        align: center;              }      table.board {        background-color: #000000;				      }    </style>		    <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="3"/>      <xsl:with-param name="rows" select="3"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="minicell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <xsl:param name="mrow" select="1"/>  <xsl:param name="mcol" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>    <xsl:value-of select="$mcol"/>    <xsl:value-of select="$mrow"/>  </xsl:attribute>    <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]=$mcol and argument[4]=$mrow and argument[5]='x']">X</xsl:if>  <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]=$mcol and argument[4]=$mrow and argument[5]='o']"><font color="#999999">O</font></xsl:if>      </td></xsl:template><xsl:template name="cell">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <table border="1"><tr>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="1"/> <xsl:with-param name="mcol" select="1"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="1"/> <xsl:with-param name="mcol" select="2"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="1"/> <xsl:with-param name="mcol" select="3"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  </tr><tr>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="2"/> <xsl:with-param name="mcol" select="1"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="2"/> <xsl:with-param name="mcol" select="2"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="2"/> <xsl:with-param name="mcol" select="3"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  </tr><tr>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="3"/> <xsl:with-param name="mcol" select="1"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="3"/> <xsl:with-param name="mcol" select="2"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="3"/> <xsl:with-param name="mcol" select="3"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  </tr></table></xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>  <td>  <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  </td>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template>  </xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.111"/>px;
+        height: <xsl:value-of select="$height * 0.111"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.111"/>px;
+        text-align: center;
+        font-weight: bold;
+        align: center;        
+      }
+      table.board {
+        background-color: #000000;				
+      }
+    </style>
+		
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="3"/>
+      <xsl:with-param name="rows" select="3"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="minicell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  <xsl:param name="mrow" select="1"/>
+  <xsl:param name="mcol" select="1"/>   
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+    <xsl:value-of select="$mcol"/>
+    <xsl:value-of select="$mrow"/>
+  </xsl:attribute>
+  
+  <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]=$mcol and argument[4]=$mrow and argument[5]='x']">X</xsl:if>
+  <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]=$mcol and argument[4]=$mrow and argument[5]='o']"><font color="#999999">O</font></xsl:if>
+    
+  </td>
+</xsl:template>
+
+<xsl:template name="cell">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <table border="1"><tr>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="1"/> <xsl:with-param name="mcol" select="1"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="1"/> <xsl:with-param name="mcol" select="2"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="1"/> <xsl:with-param name="mcol" select="3"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  </tr><tr>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="2"/> <xsl:with-param name="mcol" select="1"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="2"/> <xsl:with-param name="mcol" select="2"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="2"/> <xsl:with-param name="mcol" select="3"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  </tr><tr>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="3"/> <xsl:with-param name="mcol" select="1"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="3"/> <xsl:with-param name="mcol" select="2"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="3"/> <xsl:with-param name="mcol" select="3"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  </tr></table>
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+
+  <td>
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+  </td>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>  
+
+</xsl:stylesheet>

--- a/war/root/games/nineBoardTicTacToePie/nineBoardTicTacToe.xsl
+++ b/war/root/games/nineBoardTicTacToePie/nineBoardTicTacToe.xsl
@@ -1,1 +1,139 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.111"/>px;        height: <xsl:value-of select="$height * 0.111"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        font-size: <xsl:value-of select="$width * 0.6 * 0.111"/>px;        text-align: center;        font-weight: bold;        align: center;      }      table.board {        background-color: #000000;				      }    </style>		    <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="3"/>      <xsl:with-param name="rows" select="3"/>    </xsl:call-template>		  </div></xsl:template><xsl:template name="minicell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>  <xsl:param name="mrow" select="1"/>  <xsl:param name="mcol" select="1"/>  <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>    <xsl:value-of select="$mcol"/>    <xsl:value-of select="$mrow"/>  </xsl:attribute>  <xsl:choose>    <xsl:when test="//fact[relation='usingMarker' and argument[1]='red' and argument[2]='x']">      <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]=$mcol and argument[4]=$mrow and argument[5]='x']"><font color="#FF0000">X</font></xsl:if>      <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]=$mcol and argument[4]=$mrow and argument[5]='o']"><font color="#0000FF">O</font></xsl:if>    </xsl:when>    <xsl:otherwise>      <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]=$mcol and argument[4]=$mrow and argument[5]='x']"><font color="#0000FF">X</font></xsl:if>      <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]=$mcol and argument[4]=$mrow and argument[5]='o']"><font color="#FF0000">O</font></xsl:if>    </xsl:otherwise>  </xsl:choose>  </td></xsl:template><xsl:template name="cell">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>  <table border="1"><tr>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="1"/> <xsl:with-param name="mcol" select="1"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="1"/> <xsl:with-param name="mcol" select="2"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="1"/> <xsl:with-param name="mcol" select="3"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  </tr><tr>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="2"/> <xsl:with-param name="mcol" select="1"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="2"/> <xsl:with-param name="mcol" select="2"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="2"/> <xsl:with-param name="mcol" select="3"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  </tr><tr>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="3"/> <xsl:with-param name="mcol" select="1"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="3"/> <xsl:with-param name="mcol" select="2"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="3"/> <xsl:with-param name="mcol" select="3"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>  </tr></table></xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>  <td>  <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  </td>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.111"/>px;
+        height: <xsl:value-of select="$height * 0.111"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.111"/>px;
+        text-align: center;
+        font-weight: bold;
+        align: center;
+      }
+      table.board {
+        background-color: #000000;				
+      }
+    </style>
+		
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="3"/>
+      <xsl:with-param name="rows" select="3"/>
+    </xsl:call-template>		
+  </div>
+</xsl:template>
+
+<xsl:template name="minicell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  <xsl:param name="mrow" select="1"/>
+  <xsl:param name="mcol" select="1"/>
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+    <xsl:value-of select="$mcol"/>
+    <xsl:value-of select="$mrow"/>
+  </xsl:attribute>
+
+  <xsl:choose>
+    <xsl:when test="//fact[relation='usingMarker' and argument[1]='red' and argument[2]='x']">
+      <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]=$mcol and argument[4]=$mrow and argument[5]='x']"><font color="#FF0000">X</font></xsl:if>
+      <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]=$mcol and argument[4]=$mrow and argument[5]='o']"><font color="#0000FF">O</font></xsl:if>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]=$mcol and argument[4]=$mrow and argument[5]='x']"><font color="#0000FF">X</font></xsl:if>
+      <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]=$mcol and argument[4]=$mrow and argument[5]='o']"><font color="#FF0000">O</font></xsl:if>
+    </xsl:otherwise>
+  </xsl:choose>
+
+
+
+  </td>
+</xsl:template>
+
+<xsl:template name="cell">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+
+  <table border="1"><tr>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="1"/> <xsl:with-param name="mcol" select="1"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="1"/> <xsl:with-param name="mcol" select="2"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="1"/> <xsl:with-param name="mcol" select="3"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  </tr><tr>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="2"/> <xsl:with-param name="mcol" select="1"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="2"/> <xsl:with-param name="mcol" select="2"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="2"/> <xsl:with-param name="mcol" select="3"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  </tr><tr>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="3"/> <xsl:with-param name="mcol" select="1"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="3"/> <xsl:with-param name="mcol" select="2"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  <xsl:call-template name="minicell"> <xsl:with-param name="mrow" select="3"/> <xsl:with-param name="mcol" select="3"/> <xsl:with-param name="row" select="$row"/> <xsl:with-param name="col" select="$col"/> </xsl:call-template>
+  </tr></table>
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+
+  <td>
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+  </td>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/numbertictactoe/numbertictactoe.xsl
+++ b/war/root/games/numbertictactoe/numbertictactoe.xsl
@@ -1,1 +1,111 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.333"/>px;        height: <xsl:value-of select="$height * 0.333"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        font-size: <xsl:value-of select="$width * 0.6 * 0.333"/>px;        text-align: center;        font-weight: bold;        align: center;              }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="3"/>      <xsl:with-param name="rows" select="3"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1']"><font color="#3333CC">1</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2']"><font color="#33CC33">2</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3']"><font color="#3333CC">3</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4']"><font color="#33CC33">4</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='5']"><font color="#3333CC">5</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='6']"><font color="#33CC33">6</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='7']"><font color="#3333CC">7</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='8']"><font color="#33CC33">8</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='9']"><font color="#3333CC">9</font></xsl:if>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.333"/>px;
+        height: <xsl:value-of select="$height * 0.333"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.333"/>px;
+        text-align: center;
+        font-weight: bold;
+        align: center;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="3"/>
+      <xsl:with-param name="rows" select="3"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1']"><font color="#3333CC">1</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2']"><font color="#33CC33">2</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3']"><font color="#3333CC">3</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4']"><font color="#33CC33">4</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='5']"><font color="#3333CC">5</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='6']"><font color="#33CC33">6</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='7']"><font color="#3333CC">7</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='8']"><font color="#33CC33">8</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='9']"><font color="#3333CC">9</font></xsl:if>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/pacman2p/pacman2p.xsl
+++ b/war/root/games/pacman2p/pacman2p.xsl
@@ -1,1 +1,123 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: none;        background-color: #CCCCCC;      }      table.board {        background-color: #000000;        border-collapse: collapse;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>    <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">    <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px;</xsl:attribute>  </xsl:if>    <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">    <xsl:attribute name="style">border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">    <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">      <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px; border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>    </xsl:if>        </xsl:if>  <center>  <xsl:choose>    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='pacman']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:when>    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='blinky']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:when>    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='inky']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:when>    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='pellet']"> o </xsl:when>  </xsl:choose>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: none;
+        background-color: #CCCCCC;
+      }
+      table.board {
+        background-color: #000000;
+        border-collapse: collapse;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+  
+  <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">
+    <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px;</xsl:attribute>
+  </xsl:if>  
+  <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">
+    <xsl:attribute name="style">border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">
+    <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">
+      <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px; border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>
+    </xsl:if>      
+  </xsl:if>
+
+  <center>
+  <xsl:choose>
+    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='pacman']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='blinky']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='inky']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='pellet']"> o </xsl:when>
+  </xsl:choose>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/pacman3p/pacman3p.xsl
+++ b/war/root/games/pacman3p/pacman3p.xsl
@@ -1,1 +1,123 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: none;        background-color: #CCCCCC;      }      table.board {        background-color: #000000;        border-collapse: collapse;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>    <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">    <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px;</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">    <xsl:attribute name="style">border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">    <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">      <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px; border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>    </xsl:if>        </xsl:if>  <center>  <xsl:choose>    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='pacman']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:when>    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='blinky']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:when>    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='inky']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:when>    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='pellet']"> o </xsl:when>  </xsl:choose>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: none;
+        background-color: #CCCCCC;
+      }
+      table.board {
+        background-color: #000000;
+        border-collapse: collapse;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+  
+  <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">
+    <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px;</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">
+    <xsl:attribute name="style">border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='blockedEast' and argument[1]=$col and argument[2]=$row]">
+    <xsl:if test="//fact[relation='blockedNorth' and argument[1]=$col and argument[2]=$row]">
+      <xsl:attribute name="style">border-bottom-style: solid; border-bottom-color: black; border-bottom-width: 5px; border-right-style: solid; border-right-color: black; border-right-width: 5px;</xsl:attribute>
+    </xsl:if>      
+  </xsl:if>
+
+  <center>
+  <xsl:choose>
+    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='pacman']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='blinky']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='inky']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='location' and argument[2]=$col and argument[3]=$row and argument[1]='pellet']"> o </xsl:when>
+  </xsl:choose>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/pawnToQueen/pawnToQueen.xsl
+++ b/war/root/games/pawnToQueen/pawnToQueen.xsl
@@ -1,1 +1,112 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>    <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col_char"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wq']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bq']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col_char"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wq']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bq']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/pawnWhopping/pawnWhopping.xsl
+++ b/war/root/games/pawnWhopping/pawnWhopping.xsl
@@ -1,1 +1,108 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='x']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='o']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='x']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='o']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/peg/peg.xsl
+++ b/war/root/games/peg/peg.xsl
@@ -1,1 +1,116 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="7"/>      <xsl:with-param name="rows" select="7"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <xsl:param name="row_char" select="translate(translate(translate(translate(translate(translate(translate($row,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g')"/>  <xsl:param name="col_char" select="concat('c',$col)"/>    <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$row_char"/>    <xsl:value-of select="$col_char"/>      </xsl:attribute>  <xsl:if test="$row &lt; 3 or $row &gt; 5">    <xsl:if test="$col &lt; 3 or $col &gt; 5">      <xsl:attribute name="style">background-color: #222</xsl:attribute>    </xsl:if>  </xsl:if>  <center>  <xsl:if test="//fact[relation='hole' and argument[1]=$row_char and argument[2]=$col_char and argument[3]='peg']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="7"/>
+      <xsl:with-param name="rows" select="7"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <xsl:param name="row_char" select="translate(translate(translate(translate(translate(translate(translate($row,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g')"/>
+  <xsl:param name="col_char" select="concat('c',$col)"/>
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$row_char"/>
+    <xsl:value-of select="$col_char"/>    
+  </xsl:attribute>
+
+  <xsl:if test="$row &lt; 3 or $row &gt; 5">
+    <xsl:if test="$col &lt; 3 or $col &gt; 5">
+      <xsl:attribute name="style">background-color: #222</xsl:attribute>
+    </xsl:if>
+  </xsl:if>
+
+  <center>
+  <xsl:if test="//fact[relation='hole' and argument[1]=$row_char and argument[2]=$col_char and argument[3]='peg']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/pegEuro/pegEuro.xsl
+++ b/war/root/games/pegEuro/pegEuro.xsl
@@ -1,1 +1,121 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="7"/>      <xsl:with-param name="rows" select="7"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <xsl:param name="row_char" select="translate(translate(translate(translate(translate(translate(translate($row,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g')"/>  <xsl:param name="col_char" select="concat('c',$col)"/>    <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$row_char"/>    <xsl:value-of select="$col_char"/>      </xsl:attribute>  <xsl:if test="$row=1 or $row=7">    <xsl:if test="$col &lt; 3 or $col &gt; 5">      <xsl:attribute name="style">background-color: #222</xsl:attribute>    </xsl:if>  </xsl:if>  <xsl:if test="$row=2 or $row=6">    <xsl:if test="$col=1 or $col=7">      <xsl:attribute name="style">background-color: #222</xsl:attribute>    </xsl:if>  </xsl:if>    <center>  <xsl:if test="//fact[relation='hole' and argument[1]=$row_char and argument[2]=$col_char and argument[3]='peg']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="7"/>
+      <xsl:with-param name="rows" select="7"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <xsl:param name="row_char" select="translate(translate(translate(translate(translate(translate(translate($row,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g')"/>
+  <xsl:param name="col_char" select="concat('c',$col)"/>
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$row_char"/>
+    <xsl:value-of select="$col_char"/>    
+  </xsl:attribute>
+
+  <xsl:if test="$row=1 or $row=7">
+    <xsl:if test="$col &lt; 3 or $col &gt; 5">
+      <xsl:attribute name="style">background-color: #222</xsl:attribute>
+    </xsl:if>
+  </xsl:if>
+  <xsl:if test="$row=2 or $row=6">
+    <xsl:if test="$col=1 or $col=7">
+      <xsl:attribute name="style">background-color: #222</xsl:attribute>
+    </xsl:if>
+  </xsl:if>  
+
+  <center>
+  <xsl:if test="//fact[relation='hole' and argument[1]=$row_char and argument[2]=$col_char and argument[3]='peg']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/pentago/pentago.xsl
+++ b/war/root/games/pentago/pentago.xsl
@@ -1,1 +1,114 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.167"/>px;        height: <xsl:value-of select="$height * 0.167"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;              }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.167"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.167"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="6"/>      <xsl:with-param name="rows" select="6"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='1' and argument[2]+3=$col and argument[3]+3=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='2' and argument[2]=$col and argument[3]+3=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='3' and argument[2]=$col and argument[3]=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='4' and argument[2]+3=$col and argument[3]=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='1' and argument[2]+3=$col and argument[3]+3=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='2' and argument[2]=$col and argument[3]+3=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='3' and argument[2]=$col and argument[3]=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='4' and argument[2]+3=$col and argument[3]=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.167"/>px;
+        height: <xsl:value-of select="$height * 0.167"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.167"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.167"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="6"/>
+      <xsl:with-param name="rows" select="6"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='1' and argument[2]+3=$col and argument[3]+3=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='2' and argument[2]=$col and argument[3]+3=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='3' and argument[2]=$col and argument[3]=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='4' and argument[2]+3=$col and argument[3]=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='1' and argument[2]+3=$col and argument[3]+3=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='2' and argument[2]=$col and argument[3]+3=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='3' and argument[2]=$col and argument[3]=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='4' and argument[2]+3=$col and argument[3]=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/pentagoSuicide/pentagoSuicide.xsl
+++ b/war/root/games/pentagoSuicide/pentagoSuicide.xsl
@@ -1,1 +1,114 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.167"/>px;        height: <xsl:value-of select="$height * 0.167"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;              }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.167"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.167"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="6"/>      <xsl:with-param name="rows" select="6"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='1' and argument[2]+3=$col and argument[3]+3=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='2' and argument[2]=$col and argument[3]+3=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='3' and argument[2]=$col and argument[3]=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='4' and argument[2]+3=$col and argument[3]=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='1' and argument[2]+3=$col and argument[3]+3=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='2' and argument[2]=$col and argument[3]+3=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='3' and argument[2]=$col and argument[3]=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  <xsl:if test="//fact[relation='cellHolds' and argument[1]='4' and argument[2]+3=$col and argument[3]=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.167"/>px;
+        height: <xsl:value-of select="$height * 0.167"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.167"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.167"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="6"/>
+      <xsl:with-param name="rows" select="6"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='1' and argument[2]+3=$col and argument[3]+3=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='2' and argument[2]=$col and argument[3]+3=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='3' and argument[2]=$col and argument[3]=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='4' and argument[2]+3=$col and argument[3]=$row and argument[4]='red']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='1' and argument[2]+3=$col and argument[3]+3=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='2' and argument[2]=$col and argument[3]+3=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='3' and argument[2]=$col and argument[3]=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cellHolds' and argument[1]='4' and argument[2]+3=$col and argument[3]=$row and argument[4]='black']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:if>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/quarto/quarto.xsl
+++ b/war/root/games/quarto/quarto.xsl
@@ -1,1 +1,122 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.25"/>px;        height: <xsl:value-of select="$height * 0.25"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.25"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.25"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="4"/>      <xsl:with-param name="rows" select="4"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$row"/>    <xsl:value-of select="$col"/>      </xsl:attribute>  <xsl:choose>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],2,1)='0']"> <xsl:attribute name="style">background-color: #CCC</xsl:attribute> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],2,1)='1']"> <xsl:attribute name="style">background-color: #888</xsl:attribute> </xsl:when>    <xsl:otherwise> <xsl:attribute name="style">background-color: #CCC</xsl:attribute> </xsl:otherwise>  </xsl:choose>       <center>    <xsl:choose>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='000']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:when>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='001']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:when>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='010']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:when>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='011']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:when>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='100']"> <img class="piece" src="&ROOT;/resources/images/quarto/Black_Pawn_Flipped.png"/> </xsl:when>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='101']"> <img class="piece" src="&ROOT;/resources/images/quarto/White_Pawn_Flipped.png"/> </xsl:when>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='110']"> <img class="piece" src="&ROOT;/resources/images/quarto/Black_Knight_Flipped.png"/> </xsl:when>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='111']"> <img class="piece" src="&ROOT;/resources/images/quarto/White_Knight_Flipped.png"/> </xsl:when>    </xsl:choose>      </center>  </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.25"/>px;
+        height: <xsl:value-of select="$height * 0.25"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.25"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.25"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="4"/>
+      <xsl:with-param name="rows" select="4"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$row"/>
+    <xsl:value-of select="$col"/>    
+  </xsl:attribute>
+
+  <xsl:choose>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],2,1)='0']"> <xsl:attribute name="style">background-color: #CCC</xsl:attribute> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],2,1)='1']"> <xsl:attribute name="style">background-color: #888</xsl:attribute> </xsl:when>
+    <xsl:otherwise> <xsl:attribute name="style">background-color: #CCC</xsl:attribute> </xsl:otherwise>
+  </xsl:choose>   
+  
+  <center>
+    <xsl:choose>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='000']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:when>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='001']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:when>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='010']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:when>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='011']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:when>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='100']"> <img class="piece" src="&ROOT;/resources/images/quarto/Black_Pawn_Flipped.png"/> </xsl:when>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='101']"> <img class="piece" src="&ROOT;/resources/images/quarto/White_Pawn_Flipped.png"/> </xsl:when>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='110']"> <img class="piece" src="&ROOT;/resources/images/quarto/Black_Knight_Flipped.png"/> </xsl:when>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='111']"> <img class="piece" src="&ROOT;/resources/images/quarto/White_Knight_Flipped.png"/> </xsl:when>
+    </xsl:choose>    
+  </center>
+
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/quartoSuicide/quartoSuicide.xsl
+++ b/war/root/games/quartoSuicide/quartoSuicide.xsl
@@ -1,1 +1,122 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.25"/>px;        height: <xsl:value-of select="$height * 0.25"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.25"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.25"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="4"/>      <xsl:with-param name="rows" select="4"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$row"/>    <xsl:value-of select="$col"/>      </xsl:attribute>  <xsl:choose>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],2,1)='0']"> <xsl:attribute name="style">background-color: #CCC</xsl:attribute> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],2,1)='1']"> <xsl:attribute name="style">background-color: #888</xsl:attribute> </xsl:when>    <xsl:otherwise> <xsl:attribute name="style">background-color: #CCC</xsl:attribute> </xsl:otherwise>  </xsl:choose>       <center>    <xsl:choose>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='000']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:when>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='001']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:when>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='010']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:when>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='011']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:when>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='100']"> <img class="piece" src="&ROOT;/resources/images/quarto/Black_Pawn_Flipped.png"/> </xsl:when>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='101']"> <img class="piece" src="&ROOT;/resources/images/quarto/White_Pawn_Flipped.png"/> </xsl:when>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='110']"> <img class="piece" src="&ROOT;/resources/images/quarto/Black_Knight_Flipped.png"/> </xsl:when>      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='111']"> <img class="piece" src="&ROOT;/resources/images/quarto/White_Knight_Flipped.png"/> </xsl:when>    </xsl:choose>      </center>  </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.25"/>px;
+        height: <xsl:value-of select="$height * 0.25"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.25"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.25"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="4"/>
+      <xsl:with-param name="rows" select="4"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$row"/>
+    <xsl:value-of select="$col"/>    
+  </xsl:attribute>
+
+  <xsl:choose>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],2,1)='0']"> <xsl:attribute name="style">background-color: #CCC</xsl:attribute> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],2,1)='1']"> <xsl:attribute name="style">background-color: #888</xsl:attribute> </xsl:when>
+    <xsl:otherwise> <xsl:attribute name="style">background-color: #CCC</xsl:attribute> </xsl:otherwise>
+  </xsl:choose>   
+  
+  <center>
+    <xsl:choose>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='000']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:when>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='001']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:when>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='010']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:when>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='011']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:when>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='100']"> <img class="piece" src="&ROOT;/resources/images/quarto/Black_Pawn_Flipped.png"/> </xsl:when>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='101']"> <img class="piece" src="&ROOT;/resources/images/quarto/White_Pawn_Flipped.png"/> </xsl:when>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='110']"> <img class="piece" src="&ROOT;/resources/images/quarto/Black_Knight_Flipped.png"/> </xsl:when>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$row and argument[2]=$col and substring(argument[3],3,3)='111']"> <img class="piece" src="&ROOT;/resources/images/quarto/White_Knight_Flipped.png"/> </xsl:when>
+    </xsl:choose>    
+  </center>
+
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/qyshinsu/qyshinsu.xsl
+++ b/war/root/games/qyshinsu/qyshinsu.xsl
@@ -1,1 +1,134 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      div#board {        width:  <xsl:value-of select="$width"/>px;        height: <xsl:value-of select="$height"/>px;              }      img.board {        width:  <xsl:value-of select="$width"/>px;        height: <xsl:value-of select="$height"/>px;            }      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        border-style: hidden;        moz-border-radius: 45px;        border-radius: 45px;        background-color: transparent;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.125 * 0.9"/>px;        height: <xsl:value-of select="$height * 0.125 * 0.9"/>px;              }    </style>         <div id="board" style="position:relative">      <!-- Draw Background -->      <img class="board" src="&ROOT;/resources/images/qyshinsu/board.png"/>			       <xsl:call-template name="cells">        <xsl:with-param name="max_index" select="12"/>      </xsl:call-template>    </div>  </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="index" select="1"/>   <xsl:variable name="xfactor">    <xsl:choose>      <xsl:when test="$index=1">  0.6800 </xsl:when>      <xsl:when test="$index=2">  0.7725 </xsl:when>      <xsl:when test="$index=3">  0.7850 </xsl:when>      <xsl:when test="$index=4">  0.7200 </xsl:when>      <xsl:when test="$index=5">  0.5925 </xsl:when>      <xsl:when test="$index=6">  0.4325 </xsl:when>      <xsl:when test="$index=7">  0.2925 </xsl:when>      <xsl:when test="$index=8">  0.2025 </xsl:when>      <xsl:when test="$index=9">  0.1900 </xsl:when>      <xsl:when test="$index=10"> 0.2600 </xsl:when>      <xsl:when test="$index=11"> 0.3825 </xsl:when>      <xsl:when test="$index=12"> 0.5425 </xsl:when>    </xsl:choose>  </xsl:variable>  <xsl:variable name="yfactor">    <xsl:choose>      <xsl:when test="$index=1">  0.2525 </xsl:when>      <xsl:when test="$index=2">  0.3775 </xsl:when>      <xsl:when test="$index=3">  0.5300 </xsl:when>      <xsl:when test="$index=4">  0.6775 </xsl:when>      <xsl:when test="$index=5">  0.7675 </xsl:when>      <xsl:when test="$index=6">  0.7775 </xsl:when>      <xsl:when test="$index=7">  0.7075 </xsl:when>      <xsl:when test="$index=8">  0.5850 </xsl:when>      <xsl:when test="$index=9">  0.4300 </xsl:when>      <xsl:when test="$index=10"> 0.2900 </xsl:when>      <xsl:when test="$index=11"> 0.1975 </xsl:when>      <xsl:when test="$index=12"> 0.1875 </xsl:when>    </xsl:choose>  </xsl:variable>    <table>  <xsl:attribute name="style">    <xsl:value-of select="concat('position:absolute; left: ',$width * ($xfactor - 0.0625),'px; top: ',$height * ($yfactor - 0.05),'px')"/>		  </xsl:attribute>    <tr>  <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$index"/>  </xsl:attribute>      <xsl:variable name="value" select="//fact[relation='position' and argument[1]=$index]/argument[2]"/>  <xsl:variable name="owner" select="//fact[relation='owner' and argument[1]=$index]/argument[2]"/>    <center>    <xsl:if test="$value!='empty'">        <img class="piece">      <xsl:attribute name="src">        <xsl:if test="$owner='red'"><xsl:value-of select="concat('&ROOT;/resources/images/qyshinsu/R',$value,'.png')"/></xsl:if>        <xsl:if test="$owner='black'"><xsl:value-of select="concat('&ROOT;/resources/images/qyshinsu/B',$value,'.png')"/></xsl:if>      </xsl:attribute>      </img>    </xsl:if>  </center>      </td>  </tr>  </table></xsl:template><xsl:template name="cells">  <xsl:param name="max_index" select="1"/>  <xsl:param name="index" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="index" select="$index"/>  </xsl:call-template>  <xsl:if test="$index &lt; $max_index">    <xsl:call-template name="cells">      <xsl:with-param name="max_index" select="$max_index"/>      <xsl:with-param name="index" select="$index + 1"/>    </xsl:call-template>  </xsl:if></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      div#board {
+        width:  <xsl:value-of select="$width"/>px;
+        height: <xsl:value-of select="$height"/>px;        
+      }
+      img.board {
+        width:  <xsl:value-of select="$width"/>px;
+        height: <xsl:value-of select="$height"/>px;      
+      }
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        border-style: hidden;
+        moz-border-radius: 45px;
+        border-radius: 45px;
+        background-color: transparent;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.125 * 0.9"/>px;
+        height: <xsl:value-of select="$height * 0.125 * 0.9"/>px;        
+      }
+    </style> 
+    
+    <div id="board" style="position:relative">
+      <!-- Draw Background -->
+      <img class="board" src="&ROOT;/resources/images/qyshinsu/board.png"/>
+			
+       <xsl:call-template name="cells">
+        <xsl:with-param name="max_index" select="12"/>
+      </xsl:call-template>
+    </div>
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="index" select="1"/> 
+
+  <xsl:variable name="xfactor">
+    <xsl:choose>
+      <xsl:when test="$index=1">  0.6800 </xsl:when>
+      <xsl:when test="$index=2">  0.7725 </xsl:when>
+      <xsl:when test="$index=3">  0.7850 </xsl:when>
+      <xsl:when test="$index=4">  0.7200 </xsl:when>
+      <xsl:when test="$index=5">  0.5925 </xsl:when>
+      <xsl:when test="$index=6">  0.4325 </xsl:when>
+      <xsl:when test="$index=7">  0.2925 </xsl:when>
+      <xsl:when test="$index=8">  0.2025 </xsl:when>
+      <xsl:when test="$index=9">  0.1900 </xsl:when>
+      <xsl:when test="$index=10"> 0.2600 </xsl:when>
+      <xsl:when test="$index=11"> 0.3825 </xsl:when>
+      <xsl:when test="$index=12"> 0.5425 </xsl:when>
+    </xsl:choose>
+  </xsl:variable>
+
+
+  <xsl:variable name="yfactor">
+    <xsl:choose>
+      <xsl:when test="$index=1">  0.2525 </xsl:when>
+      <xsl:when test="$index=2">  0.3775 </xsl:when>
+      <xsl:when test="$index=3">  0.5300 </xsl:when>
+      <xsl:when test="$index=4">  0.6775 </xsl:when>
+      <xsl:when test="$index=5">  0.7675 </xsl:when>
+      <xsl:when test="$index=6">  0.7775 </xsl:when>
+      <xsl:when test="$index=7">  0.7075 </xsl:when>
+      <xsl:when test="$index=8">  0.5850 </xsl:when>
+      <xsl:when test="$index=9">  0.4300 </xsl:when>
+      <xsl:when test="$index=10"> 0.2900 </xsl:when>
+      <xsl:when test="$index=11"> 0.1975 </xsl:when>
+      <xsl:when test="$index=12"> 0.1875 </xsl:when>
+    </xsl:choose>
+  </xsl:variable>
+  
+  <table>
+  <xsl:attribute name="style">
+    <xsl:value-of select="concat('position:absolute; left: ',$width * ($xfactor - 0.0625),'px; top: ',$height * ($yfactor - 0.05),'px')"/>		
+  </xsl:attribute>
+  
+  <tr>
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$index"/>
+  </xsl:attribute>
+    
+  <xsl:variable name="value" select="//fact[relation='position' and argument[1]=$index]/argument[2]"/>
+  <xsl:variable name="owner" select="//fact[relation='owner' and argument[1]=$index]/argument[2]"/>
+  
+  <center>
+    <xsl:if test="$value!='empty'">  
+      <img class="piece">
+      <xsl:attribute name="src">
+        <xsl:if test="$owner='red'"><xsl:value-of select="concat('&ROOT;/resources/images/qyshinsu/R',$value,'.png')"/></xsl:if>
+        <xsl:if test="$owner='black'"><xsl:value-of select="concat('&ROOT;/resources/images/qyshinsu/B',$value,'.png')"/></xsl:if>
+      </xsl:attribute>
+      </img>
+    </xsl:if>
+  </center>  
+  
+  </td>
+  </tr>
+  </table>
+</xsl:template>
+
+<xsl:template name="cells">
+  <xsl:param name="max_index" select="1"/>
+  <xsl:param name="index" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="index" select="$index"/>
+  </xsl:call-template>
+
+  <xsl:if test="$index &lt; $max_index">
+    <xsl:call-template name="cells">
+      <xsl:with-param name="max_index" select="$max_index"/>
+      <xsl:with-param name="index" select="$index + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/sheepAndWolf/sheepAndWolf.xsl
+++ b/war/root/games/sheepAndWolf/sheepAndWolf.xsl
@@ -1,1 +1,116 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <xsl:param name="row_char" select="concat('c',$row)"/>  <xsl:param name="col_char" select="concat('c',$col)"/>  <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$row_char"/>    <xsl:value-of select="$col_char"/>      </xsl:attribute>  <xsl:if test="($row + $col) mod 2 = 1">    <xsl:attribute name="style">background-color: #555555</xsl:attribute>    </xsl:if>    <center>  <xsl:choose>    <xsl:when test="//fact[relation='cell' and argument[1]=$row_char and argument[2]=$col_char and argument[3]='w']"> <img class="piece" src="&ROOT;/resources/images/icons/wolf.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$row_char and argument[2]=$col_char and argument[3]='s']"> <img class="piece" src="&ROOT;/resources/images/icons/sheep.png"/> </xsl:when>  </xsl:choose>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <xsl:param name="row_char" select="concat('c',$row)"/>
+  <xsl:param name="col_char" select="concat('c',$col)"/>
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$row_char"/>
+    <xsl:value-of select="$col_char"/>    
+  </xsl:attribute>
+  <xsl:if test="($row + $col) mod 2 = 1">
+    <xsl:attribute name="style">background-color: #555555</xsl:attribute>  
+  </xsl:if>  
+
+  <center>
+  <xsl:choose>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row_char and argument[2]=$col_char and argument[3]='w']"> <img class="piece" src="&ROOT;/resources/images/icons/wolf.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$row_char and argument[2]=$col_char and argument[3]='s']"> <img class="piece" src="&ROOT;/resources/images/icons/sheep.png"/> </xsl:when>
+  </xsl:choose>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/simultaneousWin2/simultaneousWin2.xsl
+++ b/war/root/games/simultaneousWin2/simultaneousWin2.xsl
@@ -1,1 +1,111 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.25"/>px;        height: <xsl:value-of select="$height * 0.25"/>px;        border: 1px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;              }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="4"/>      <xsl:with-param name="rows" select="4"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">    <xsl:attribute name="id">      <xsl:value-of select="'cell_'"/>      <xsl:value-of select="$col"/>      <xsl:value-of select="$row"/>    </xsl:attribute>        <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1']">      <xsl:attribute name="style">background-color: #600</xsl:attribute>                      </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2']">      <xsl:attribute name="style">background-color: #660</xsl:attribute>    </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3']">      <xsl:attribute name="style">background-color: #690</xsl:attribute>    </xsl:if>    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4']">      <xsl:attribute name="style">background-color: #6F0</xsl:attribute>    </xsl:if>  </td></xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.25"/>px;
+        height: <xsl:value-of select="$height * 0.25"/>px;
+        border: 1px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="4"/>
+      <xsl:with-param name="rows" select="4"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+    <xsl:attribute name="id">
+      <xsl:value-of select="'cell_'"/>
+      <xsl:value-of select="$col"/>
+      <xsl:value-of select="$row"/>
+    </xsl:attribute>
+    
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='1']">
+      <xsl:attribute name="style">background-color: #600</xsl:attribute>                  
+    </xsl:if>
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='2']">
+      <xsl:attribute name="style">background-color: #660</xsl:attribute>
+    </xsl:if>
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='3']">
+      <xsl:attribute name="style">background-color: #690</xsl:attribute>
+    </xsl:if>
+    <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='4']">
+      <xsl:attribute name="style">background-color: #6F0</xsl:attribute>
+    </xsl:if>
+  </td>
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/skirmish/skirmish.xsl
+++ b/war/root/games/skirmish/skirmish.xsl
@@ -1,1 +1,118 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whitePawn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteRook']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKing']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackRook']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKing']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whitePawn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteRook']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKing']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackRook']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKing']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/skirmishFinal1/skirmish.xsl
+++ b/war/root/games/skirmishFinal1/skirmish.xsl
@@ -1,1 +1,118 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whitePawn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteRook']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKing']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackRook']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKing']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whitePawn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteRook']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKing']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackRook']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKing']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/skirmishFinal2/skirmish.xsl
+++ b/war/root/games/skirmishFinal2/skirmish.xsl
@@ -1,1 +1,118 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whitePawn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteRook']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKing']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackRook']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKing']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whitePawn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteRook']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKing']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackRook']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKing']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/skirmishFinal3/skirmish.xsl
+++ b/war/root/games/skirmishFinal3/skirmish.xsl
@@ -1,1 +1,118 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whitePawn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteRook']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKing']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackRook']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKing']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whitePawn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteRook']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKing']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackRook']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKing']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/skirmishHoles/skirmishHoles.xsl
+++ b/war/root/games/skirmishHoles/skirmishHoles.xsl
@@ -1,1 +1,122 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='cellOffLimits' and argument[1]=$col and argument[2]=$row]">    <xsl:attribute name="style">background-color: #222</xsl:attribute>  </xsl:if>  <center>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whitePawn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteRook']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKing']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackRook']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKing']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='cellOffLimits' and argument[1]=$col and argument[2]=$row]">
+    <xsl:attribute name="style">background-color: #222</xsl:attribute>
+  </xsl:if>
+
+  <center>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whitePawn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteRook']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKing']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackRook']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKing']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/slaughter/chess.xsl
+++ b/war/root/games/slaughter/chess.xsl
@@ -1,1 +1,120 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>  <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col_char"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wr']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wk']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wq']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wb']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='br']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bk']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bq']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bb']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <xsl:param name="col_char" select="translate(translate(translate(translate(translate(translate(translate(translate($col,1,'a'),2,'b'),3,'c'),4,'d'),5,'e'),6,'f'),7,'g'),8,'h')"/>
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col_char"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wp']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wr']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wk']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wq']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='wb']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bp']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='br']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bk']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bq']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col_char and argument[2]=$row and argument[3]='bb']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/snake2p/snake2p.xsl
+++ b/war/root/games/snake2p/snake2p.xsl
@@ -1,1 +1,115 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.166"/>px;        height: <xsl:value-of select="$height * 0.166"/>px;        border: none;        background-color: #CCCCCC;      }      table.board {        background-color: #000000;        border-collapse: collapse;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.166"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.166"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="6"/>      <xsl:with-param name="rows" select="6"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>    <xsl:if test="//fact[relation='cell' and argument[3]='f' and argument[1]+1=$col and argument[2]+1=$row]">    <xsl:attribute name="style">background-color: #9CF</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[3]='w' and argument[1]+1=$col and argument[2]+1=$row]">    <xsl:attribute name="style">background-color: #333</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[3]='redHead' and argument[1]+1=$col and argument[2]+1=$row]">    <xsl:attribute name="style">background-color: #C00</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[3]='blueHead' and argument[1]+1=$col and argument[2]+1=$row]">    <xsl:attribute name="style">background-color: #00C</xsl:attribute>  </xsl:if>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.166"/>px;
+        height: <xsl:value-of select="$height * 0.166"/>px;
+        border: none;
+        background-color: #CCCCCC;
+      }
+      table.board {
+        background-color: #000000;
+        border-collapse: collapse;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.166"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.166"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="6"/>
+      <xsl:with-param name="rows" select="6"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+  
+  <xsl:if test="//fact[relation='cell' and argument[3]='f' and argument[1]+1=$col and argument[2]+1=$row]">
+    <xsl:attribute name="style">background-color: #9CF</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[3]='w' and argument[1]+1=$col and argument[2]+1=$row]">
+    <xsl:attribute name="style">background-color: #333</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[3]='redHead' and argument[1]+1=$col and argument[2]+1=$row]">
+    <xsl:attribute name="style">background-color: #C00</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[3]='blueHead' and argument[1]+1=$col and argument[2]+1=$row]">
+    <xsl:attribute name="style">background-color: #00C</xsl:attribute>
+  </xsl:if>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/snakeParallel/snakeParallel.xsl
+++ b/war/root/games/snakeParallel/snakeParallel.xsl
@@ -1,1 +1,109 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: none;        background-color: #CCCCCC;      }      table.board {        background-color: #000000;        border-collapse: collapse;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="4"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>    <xsl:if test="//fact[relation='cell' and argument[4]='snake' and (argument[2] + ((argument[1]-1) * 4))=$col and argument[3]=$row]">    <xsl:attribute name="style">background-color: #C00</xsl:attribute>  </xsl:if>  <xsl:if test="//fact[relation='cell' and argument[4]='body' and (argument[2] + ((argument[1]-1) * 4))=$col and argument[3]=$row]">    <xsl:attribute name="style">background-color: #CC0</xsl:attribute>  </xsl:if>      </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: none;
+        background-color: #CCCCCC;
+      }
+      table.board {
+        background-color: #000000;
+        border-collapse: collapse;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="4"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+  
+  <xsl:if test="//fact[relation='cell' and argument[4]='snake' and (argument[2] + ((argument[1]-1) * 4))=$col and argument[3]=$row]">
+    <xsl:attribute name="style">background-color: #C00</xsl:attribute>
+  </xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[4]='body' and (argument[2] + ((argument[1]-1) * 4))=$col and argument[3]=$row]">
+    <xsl:attribute name="style">background-color: #CC0</xsl:attribute>
+  </xsl:if>  
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/solitaireChineseCheckers/chineseCheckers.xsl
+++ b/war/root/games/solitaireChineseCheckers/chineseCheckers.xsl
@@ -1,1 +1,184 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">					#main					{						position:   relative;						width:  <xsl:value-of select="$width"/>px;						height: <xsl:value-of select="$height"/>px;						padding:    10px;						border:     2px solid #b17735;						background: transparent url(&ROOT;/resources/images/chineseCheckers/ccboard.png) repeat top left; 					}							div.teal					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #00ffff;					}					div.red					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ff0000;					}					div.blue					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #0000ff;					}					div.green					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #00ff00;					}					div.yellow					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ffff00;					}					div.magenta					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #ff00ff;					}					div.blank					{						width: <xsl:value-of select="$width * 0.142857143"/>px;						height: <xsl:value-of select="$height * 0.113"/>px;						background: #cca083;					}					#a1,#i1					{						margin-left: <xsl:value-of select="$width * 0.428571429"/>px;						clear: left;					}					#b1,#h1					{						margin-left: <xsl:value-of select="$width * 0.357142857"/>px;						float: left;						clear: left;					}					#c1,#g1					{						margin-left: 0px;						clear: left;						float: left;					}					#d1,#f1					{						margin-left: <xsl:value-of select="$width * 0.0714285714"/>px;						clear: left;						float: left;					}					#e1					{						margin-left: <xsl:value-of select="$width * 0.142857143"/>px;						clear: left;						float: left;					}      img.piece {      	width: <xsl:value-of select="$width * 0.142857143"/>px;      	height: <xsl:value-of select="$height * 0.113"/>px;           }					    </style>        <div id="main">    	<xsl:call-template name="cell"><xsl:with-param name="loc">a1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">b1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">b2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">c7</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">d6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">e5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">f6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g3</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g4</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g5</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g6</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">g7</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">h1</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">h2</xsl:with-param></xsl:call-template>    	<xsl:call-template name="cell"><xsl:with-param name="loc">i1</xsl:with-param></xsl:call-template>    </div>   </div>  </xsl:template><xsl:template name="cell">  <xsl:param name="loc" select="a1"/>  <div style="float: left">	<xsl:attribute name="id"><xsl:value-of select="$loc"/></xsl:attribute>	  <xsl:for-each select="//fact[relation='cell' and argument[1]=$loc]">			<xsl:choose>			    <xsl:when test="argument[2]='yellow'">				<xsl:attribute name="class">yellow</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>			</xsl:when>		    <xsl:when test="argument[2]='magenta'">				<xsl:attribute name="class">magenta</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>	 	    <xsl:when test="argument[2]='teal'">				<xsl:attribute name="class">teal</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='green'">				<xsl:attribute name="class">green</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='red'">				<xsl:attribute name="class">red</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:when test="argument[2]='blue'">				<xsl:attribute name="class">blue</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>		    </xsl:when>		    <xsl:otherwise>		    	<!-- Old-style blank space, where there's an explicit representation of the blank square -->				<xsl:attribute name="class">blank</xsl:attribute>				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>		  	</xsl:otherwise>		</xsl:choose>	</xsl:for-each>	<xsl:if test="not (//fact[relation='cell' and argument[1]=$loc])">    	<!-- New-style blank space, with no explicit representation in the XML -->    	<xsl:attribute name="class">blank</xsl:attribute>		<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>    </xsl:if>  </div></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+					#main
+					{
+						position:   relative;
+						width:  <xsl:value-of select="$width"/>px;
+						height: <xsl:value-of select="$height"/>px;
+						padding:    10px;
+						border:     2px solid #b17735;
+						background: transparent url(&ROOT;/resources/images/chineseCheckers/ccboard.png) repeat top left; 
+					}		
+					div.teal
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #00ffff;
+					}
+					div.red
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ff0000;
+					}
+					div.blue
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #0000ff;
+					}
+					div.green
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #00ff00;
+					}
+					div.yellow
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ffff00;
+					}
+					div.magenta
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #ff00ff;
+					}
+					div.blank
+					{
+						width: <xsl:value-of select="$width * 0.142857143"/>px;
+						height: <xsl:value-of select="$height * 0.113"/>px;
+						background: #cca083;
+					}
+					#a1,#i1
+					{
+						margin-left: <xsl:value-of select="$width * 0.428571429"/>px;
+						clear: left;
+					}
+					#b1,#h1
+					{
+						margin-left: <xsl:value-of select="$width * 0.357142857"/>px;
+						float: left;
+						clear: left;
+					}
+					#c1,#g1
+					{
+						margin-left: 0px;
+						clear: left;
+						float: left;
+					}
+					#d1,#f1
+					{
+						margin-left: <xsl:value-of select="$width * 0.0714285714"/>px;
+						clear: left;
+						float: left;
+					}
+					#e1
+					{
+						margin-left: <xsl:value-of select="$width * 0.142857143"/>px;
+						clear: left;
+						float: left;
+					}
+      img.piece {
+      	width: <xsl:value-of select="$width * 0.142857143"/>px;
+      	height: <xsl:value-of select="$height * 0.113"/>px;     
+      }					
+    </style>
+    
+    <div id="main">
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">a1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">b1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">b2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">c7</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">d6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">e5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">f6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g3</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g4</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g5</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g6</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">g7</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">h1</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">h2</xsl:with-param></xsl:call-template>
+    	<xsl:call-template name="cell"><xsl:with-param name="loc">i1</xsl:with-param></xsl:call-template>
+    </div> 
+
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell">
+  <xsl:param name="loc" select="a1"/>
+
+  <div style="float: left">
+	<xsl:attribute name="id"><xsl:value-of select="$loc"/></xsl:attribute>
+	  <xsl:for-each select="//fact[relation='cell' and argument[1]=$loc]">
+			<xsl:choose>
+			    <xsl:when test="argument[2]='yellow'">
+				<xsl:attribute name="class">yellow</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+			</xsl:when>
+		    <xsl:when test="argument[2]='magenta'">
+				<xsl:attribute name="class">magenta</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+	 	    <xsl:when test="argument[2]='teal'">
+				<xsl:attribute name="class">teal</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='green'">
+				<xsl:attribute name="class">green</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='red'">
+				<xsl:attribute name="class">red</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:when test="argument[2]='blue'">
+				<xsl:attribute name="class">blue</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpit.png"/>
+		    </xsl:when>
+		    <xsl:otherwise>
+		    	<!-- Old-style blank space, where there's an explicit representation of the blank square -->
+				<xsl:attribute name="class">blank</xsl:attribute>
+				<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>
+		  	</xsl:otherwise>
+		</xsl:choose>
+	</xsl:for-each>
+	<xsl:if test="not (//fact[relation='cell' and argument[1]=$loc])">
+    	<!-- New-style blank space, with no explicit representation in the XML -->
+    	<xsl:attribute name="class">blank</xsl:attribute>
+		<img class="piece" src="&ROOT;/resources/images/chineseCheckers/boardpitb.png"/>
+    </xsl:if>
+  </div>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/strangeSkirmish/skirmish.xsl
+++ b/war/root/games/strangeSkirmish/skirmish.xsl
@@ -1,1 +1,118 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.125"/>px;        height: <xsl:value-of select="$height * 0.125"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="8"/>      <xsl:with-param name="rows" select="8"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>     <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <center>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whitePawn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteRook']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKing']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackRook']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKing']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>    </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.125"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.125"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.125"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="8"/>
+      <xsl:with-param name="rows" select="8"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+  
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <center>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whitePawn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteRook']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKing']"> <img class="piece" src="&ROOT;/resources/images/chess/White_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='whiteBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Bishop.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackRook']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Rook.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKing']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_King.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackQueen']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Queen.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:if>
+  <xsl:if test="//fact[relation='location' and argument[1]=$col and argument[2]=$row and argument[3]='blackBishop']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Bishop.png"/> </xsl:if>  
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/ticTacToe/ticTacToe.xsl
+++ b/war/root/games/ticTacToe/ticTacToe.xsl
@@ -1,1 +1,104 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.333"/>px;        height: <xsl:value-of select="$height * 0.333"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        font-size: <xsl:value-of select="$width * 0.6 * 0.333"/>px;        text-align: center;        font-weight: bold;        align: center;      }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="3"/>      <xsl:with-param name="rows" select="3"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.333"/>px;
+        height: <xsl:value-of select="$height * 0.333"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.333"/>px;
+        text-align: center;
+        font-weight: bold;
+        align: center;
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="3"/>
+      <xsl:with-param name="rows" select="3"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/ticTacToeLarge/ticTacToeLarge.xsl
+++ b/war/root/games/ticTacToeLarge/ticTacToeLarge.xsl
@@ -1,1 +1,104 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.2"/>px;        height: <xsl:value-of select="$height * 0.2"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        font-size: <xsl:value-of select="$width * 0.6 * 0.2"/>px;        text-align: center;        font-weight: bold;        align: center;              }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="5"/>      <xsl:with-param name="rows" select="5"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>  <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.2"/>px;
+        height: <xsl:value-of select="$height * 0.2"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.2"/>px;
+        text-align: center;
+        font-weight: bold;
+        align: center;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="5"/>
+      <xsl:with-param name="rows" select="5"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>
+  <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/ticTacToeLargeSuicide/ticTacToeLargeSuicide.xsl
+++ b/war/root/games/ticTacToeLargeSuicide/ticTacToeLargeSuicide.xsl
@@ -1,1 +1,104 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.2"/>px;        height: <xsl:value-of select="$height * 0.2"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        font-size: <xsl:value-of select="$width * 0.6 * 0.2"/>px;        text-align: center;        font-weight: bold;        align: center;      }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="5"/>      <xsl:with-param name="rows" select="5"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>  <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.2"/>px;
+        height: <xsl:value-of select="$height * 0.2"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.2"/>px;
+        text-align: center;
+        font-weight: bold;
+        align: center;
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="5"/>
+      <xsl:with-param name="rows" select="5"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>
+  <xsl:if test="//fact[relation='mark' and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/ticTacToeParallel/ticTacToeParallel.xsl
+++ b/war/root/games/ticTacToeParallel/ticTacToeParallel.xsl
@@ -1,1 +1,128 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.166"/>px;        height: <xsl:value-of select="$height * 0.166"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        font-size: <xsl:value-of select="$width * 0.6 * 0.166"/>px;        text-align: center;        font-weight: bold;        align: center;      }      table.board {        background-color: #000000;      }    </style>        <table><tr><td>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="3"/>      <xsl:with-param name="rows" select="3"/>      <xsl:with-param name="board" select="1"/>    </xsl:call-template>        </td><td style="width: 3px"></td><td>    <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="3"/>      <xsl:with-param name="rows" select="3"/>      <xsl:with-param name="board" select="2"/>    </xsl:call-template>        </td></tr></table>  </div></xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>  <xsl:param name="board" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>    <xsl:value-of select="$board"/>  </xsl:attribute>  <xsl:if test="//fact[relation=concat('cell',$board) and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>  <xsl:if test="//fact[relation=concat('cell',$board) and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>      </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>  <xsl:param name="board" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>    <xsl:with-param name="board" select="$board"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>      <xsl:with-param name="board" select="$board"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <xsl:param name="row" select="1"/>  <xsl:param name="board" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="board" select="$board"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>      <xsl:with-param name="board" select="$board"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <xsl:param name="board" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="board" select="$board"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.166"/>px;
+        height: <xsl:value-of select="$height * 0.166"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.166"/>px;
+        text-align: center;
+        font-weight: bold;
+        align: center;
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <table><tr><td>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="3"/>
+      <xsl:with-param name="rows" select="3"/>
+      <xsl:with-param name="board" select="1"/>
+    </xsl:call-template>
+    
+    </td><td style="width: 3px"></td><td>
+
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="3"/>
+      <xsl:with-param name="rows" select="3"/>
+      <xsl:with-param name="board" select="2"/>
+    </xsl:call-template>
+    
+    </td></tr></table>
+  </div>
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  <xsl:param name="board" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+    <xsl:value-of select="$board"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation=concat('cell',$board) and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>
+  <xsl:if test="//fact[relation=concat('cell',$board) and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>  
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  <xsl:param name="board" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+    <xsl:with-param name="board" select="$board"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+      <xsl:with-param name="board" select="$board"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="board" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="board" select="$board"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+      <xsl:with-param name="board" select="$board"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+  <xsl:param name="board" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="board" select="$board"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/ticTacToeSerial/ticTacToeSerial.xsl
+++ b/war/root/games/ticTacToeSerial/ticTacToeSerial.xsl
@@ -1,1 +1,128 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.166"/>px;        height: <xsl:value-of select="$height * 0.166"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        font-size: <xsl:value-of select="$width * 0.6 * 0.166"/>px;        text-align: center;        font-weight: bold;        align: center;              }      table.board {        background-color: #000000;      }    </style>        <table><tr><td>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="3"/>      <xsl:with-param name="rows" select="3"/>      <xsl:with-param name="board" select="1"/>    </xsl:call-template>        </td><td style="width: 3px"></td><td>    <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="3"/>      <xsl:with-param name="rows" select="3"/>      <xsl:with-param name="board" select="2"/>    </xsl:call-template>        </td></tr></table>  </div></xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>  <xsl:param name="board" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>    <xsl:value-of select="$board"/>  </xsl:attribute>  <xsl:if test="//fact[relation=concat('cell',$board) and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>  <xsl:if test="//fact[relation=concat('cell',$board) and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>      </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>  <xsl:param name="board" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>    <xsl:with-param name="board" select="$board"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>      <xsl:with-param name="board" select="$board"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <xsl:param name="row" select="1"/>  <xsl:param name="board" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="board" select="$board"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>      <xsl:with-param name="board" select="$board"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <xsl:param name="board" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="board" select="$board"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.166"/>px;
+        height: <xsl:value-of select="$height * 0.166"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.166"/>px;
+        text-align: center;
+        font-weight: bold;
+        align: center;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <table><tr><td>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="3"/>
+      <xsl:with-param name="rows" select="3"/>
+      <xsl:with-param name="board" select="1"/>
+    </xsl:call-template>
+    
+    </td><td style="width: 3px"></td><td>
+
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="3"/>
+      <xsl:with-param name="rows" select="3"/>
+      <xsl:with-param name="board" select="2"/>
+    </xsl:call-template>
+    
+    </td></tr></table>
+  </div>
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  <xsl:param name="board" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+    <xsl:value-of select="$board"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation=concat('cell',$board) and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>
+  <xsl:if test="//fact[relation=concat('cell',$board) and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>  
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  <xsl:param name="board" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+    <xsl:with-param name="board" select="$board"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+      <xsl:with-param name="board" select="$board"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="board" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="board" select="$board"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+      <xsl:with-param name="board" select="$board"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+  <xsl:param name="board" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="board" select="$board"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/ticTicToe/ticTicToe.xsl
+++ b/war/root/games/ticTicToe/ticTicToe.xsl
@@ -1,1 +1,104 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.333"/>px;        height: <xsl:value-of select="$height * 0.333"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        font-size: <xsl:value-of select="$width * 0.6 * 0.133"/>px;        text-align: center;        font-weight: bold;        align: center;              }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="3"/>      <xsl:with-param name="rows" select="3"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.333"/>px;
+        height: <xsl:value-of select="$height * 0.333"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.133"/>px;
+        text-align: center;
+        font-weight: bold;
+        align: center;        
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="3"/>
+      <xsl:with-param name="rows" select="3"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/tictactoe_3player/tictactoe_3player.xsl
+++ b/war/root/games/tictactoe_3player/tictactoe_3player.xsl
@@ -1,1 +1,105 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.2"/>px;        height: <xsl:value-of select="$height * 0.2"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        font-size: <xsl:value-of select="$width * 0.6 * 0.2"/>px;        text-align: center;        font-weight: bold;        align: center;      }      table.board {        background-color: #000000;      }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="5"/>      <xsl:with-param name="rows" select="5"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='z']"><font color="#333333">Z</font></xsl:if>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.2"/>px;
+        height: <xsl:value-of select="$height * 0.2"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        font-size: <xsl:value-of select="$width * 0.6 * 0.2"/>px;
+        text-align: center;
+        font-weight: bold;
+        align: center;
+      }
+      table.board {
+        background-color: #000000;
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="5"/>
+      <xsl:with-param name="rows" select="5"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='x']">X</xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='o']"><font color="#999999">O</font></xsl:if>
+  <xsl:if test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='z']"><font color="#333333">Z</font></xsl:if>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/tron_10x10/tron_10x10.xsl
+++ b/war/root/games/tron_10x10/tron_10x10.xsl
@@ -1,1 +1,138 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      table.board      {        background-color: #000000;      }      table.board td      {        width:  <xsl:value-of select="$width * 0.08"/>px;        height: <xsl:value-of select="$height * 0.08"/>px;        border: 2px solid #000;      }      table.board td.unvisited      {        background-color: #ffffff;      }      table.board td.visited      {        background-color: #000000;      }      table.board td.red      {        background-color: #ff0000;      }      table.board td.blue      {        background-color: #0000ff;      }    </style>    <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="12"/>      <xsl:with-param name="rows" select="12"/>    </xsl:call-template>		  </div></xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>  <td>  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>    <xsl:value-of select="$col"/>    <xsl:value-of select="'_'"/>    <xsl:value-of select="$row"/>  </xsl:attribute>  <xsl:attribute name="class">    <xsl:choose>      <xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='v']">        <xsl:value-of select="'visited'"/>      </xsl:when>      <xsl:when test="//fact[relation='position' and argument[1]='red' and argument[2]=$col and argument[3]=$row]">        <xsl:value-of select="'red'"/>      </xsl:when>      <xsl:when test="//fact[relation='position' and argument[1]='blue' and argument[2]=$col and argument[3]=$row]">        <xsl:value-of select="'blue'"/>      </xsl:when>      <xsl:otherwise>        <xsl:value-of select="'unvisited'"/>      </xsl:otherwise>    </xsl:choose>  </xsl:attribute>  </td></xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="0"/>  <xsl:call-template name="cell">    <xsl:with-param name="row" select="11 - $row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols - 1">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <xsl:param name="row" select="0"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows - 1">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      table.board
+      {
+        background-color: #000000;
+      }
+
+      table.board td
+      {
+        width:  <xsl:value-of select="$width * 0.08"/>px;
+        height: <xsl:value-of select="$height * 0.08"/>px;
+        border: 2px solid #000;
+      }
+
+      table.board td.unvisited
+      {
+        background-color: #ffffff;
+      }
+
+      table.board td.visited
+      {
+        background-color: #000000;
+      }
+
+      table.board td.red
+      {
+        background-color: #ff0000;
+      }
+
+      table.board td.blue
+      {
+        background-color: #0000ff;
+      }
+
+    </style>
+
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="12"/>
+      <xsl:with-param name="rows" select="12"/>
+    </xsl:call-template>		
+  </div>
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+
+  <td>
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>
+    <xsl:value-of select="$col"/>
+    <xsl:value-of select="'_'"/>
+    <xsl:value-of select="$row"/>
+  </xsl:attribute>
+
+  <xsl:attribute name="class">
+    <xsl:choose>
+      <xsl:when test="//fact[relation='cell' and argument[1]=$col and argument[2]=$row and argument[3]='v']">
+        <xsl:value-of select="'visited'"/>
+      </xsl:when>
+      <xsl:when test="//fact[relation='position' and argument[1]='red' and argument[2]=$col and argument[3]=$row]">
+        <xsl:value-of select="'red'"/>
+      </xsl:when>
+      <xsl:when test="//fact[relation='position' and argument[1]='blue' and argument[2]=$col and argument[3]=$row]">
+        <xsl:value-of select="'blue'"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="'unvisited'"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:attribute>
+
+  </td>
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="0"/>
+
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="11 - $row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols - 1">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+  <xsl:param name="row" select="0"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows - 1">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/war/root/games/ttcc4_2player/ttcc4_2player.xsl
+++ b/war/root/games/ttcc4_2player/ttcc4_2player.xsl
@@ -1,1 +1,125 @@
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"><xsl:param name="width" select="400"/><xsl:param name="height" select="400"/><xsl:template name="main" match="/">  <div>    <!-- Set Style -->    <style type="text/css" media="all">      td.cell {        width:  <xsl:value-of select="$width * 0.142"/>px;        height: <xsl:value-of select="$height * 0.142"/>px;        border: 2px solid #000;        background-color: #CCCCCC;        align: center;        valign: middle;      }      table.board {        background-color: #000000;      }      img.piece {        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;              }    </style>        <!-- Draw Board -->    <xsl:call-template name="board">      <xsl:with-param name="cols" select="7"/>      <xsl:with-param name="rows" select="7"/>    </xsl:call-template>		      </div>  </xsl:template><xsl:template name="cell" match="state/fact">  <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>   <xsl:param name="true_row" select="$col"/>  <xsl:param name="true_col" select="8 - $row"/>  <td class="cell">  <xsl:attribute name="id">    <xsl:value-of select="'cell_'"/>        <xsl:value-of select="$true_row"/>       <xsl:value-of select="$true_col"/>   </xsl:attribute>  <xsl:choose>    <xsl:when test="($true_row=1 or $true_row=7) and ($true_col &lt; 3 or $true_col &gt; 5)"> <xsl:attribute name="style">background-color: #222</xsl:attribute> </xsl:when>    <xsl:when test="$true_col=1 or $true_col=7"> <xsl:attribute name="style">background-color: #222</xsl:attribute> </xsl:when>    <xsl:when test="$true_row &lt; 3 or $true_row &gt; 5 or $true_col &lt; 3 or $true_col &gt; 5"> <xsl:attribute name="style">background-color: #888</xsl:attribute> </xsl:when>  </xsl:choose>    <center>  <xsl:choose>    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='lightDisc']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='lightPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='lightChecker']"> <img class="piece" src="&ROOT;/resources/images/checkers/red_king.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='lightKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='darkDisc']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='darkPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='darkChecker']"> <img class="piece" src="&ROOT;/resources/images/checkers/black_king.png"/> </xsl:when>    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='darkKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:when>  </xsl:choose>  </center>    </td>  </xsl:template><xsl:template name="board_row">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <xsl:param name="col" select="1"/>    <xsl:call-template name="cell">    <xsl:with-param name="row" select="$row"/>    <xsl:with-param name="col" select="$col"/>  </xsl:call-template>  <xsl:if test="$col &lt; $cols">    <xsl:call-template name="board_row">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row"/>      <xsl:with-param name="col" select="$col + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board_rows">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>    <xsl:param name="row" select="1"/>  <tr>  <xsl:call-template name="board_row">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>    <xsl:with-param name="row" select="$row"/>  </xsl:call-template>  </tr>  <xsl:if test="$row &lt; $rows">    <xsl:call-template name="board_rows">      <xsl:with-param name="cols" select="$cols"/>      <xsl:with-param name="rows" select="$rows"/>      <xsl:with-param name="row" select="$row + 1"/>    </xsl:call-template>  </xsl:if></xsl:template><xsl:template name="board">  <xsl:param name="cols" select="1"/>  <xsl:param name="rows" select="1"/>  <table class="board">  <xsl:call-template name="board_rows">    <xsl:with-param name="cols" select="$cols"/>    <xsl:with-param name="rows" select="$rows"/>  </xsl:call-template>  </table></xsl:template></xsl:stylesheet>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:param name="width" select="400"/>
+<xsl:param name="height" select="400"/>
+
+<xsl:template name="main" match="/">
+  <div>
+    <!-- Set Style -->
+    <style type="text/css" media="all">
+      td.cell {
+        width:  <xsl:value-of select="$width * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.142"/>px;
+        border: 2px solid #000;
+        background-color: #CCCCCC;
+        align: center;
+        valign: middle;
+      }
+      table.board {
+        background-color: #000000;
+      }
+      img.piece {
+        width: <xsl:value-of select="$width * 0.9 * 0.142"/>px;
+        height: <xsl:value-of select="$height * 0.9 * 0.142"/>px;        
+      }
+    </style>
+    
+    <!-- Draw Board -->
+    <xsl:call-template name="board">
+      <xsl:with-param name="cols" select="7"/>
+      <xsl:with-param name="rows" select="7"/>
+    </xsl:call-template>		    
+  </div>  
+</xsl:template>
+
+<xsl:template name="cell" match="state/fact">
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/> 
+
+  <xsl:param name="true_row" select="$col"/>
+  <xsl:param name="true_col" select="8 - $row"/>
+
+  <td class="cell">
+  <xsl:attribute name="id">
+    <xsl:value-of select="'cell_'"/>    
+    <xsl:value-of select="$true_row"/>   
+    <xsl:value-of select="$true_col"/> 
+  </xsl:attribute>
+
+  <xsl:choose>
+    <xsl:when test="($true_row=1 or $true_row=7) and ($true_col &lt; 3 or $true_col &gt; 5)"> <xsl:attribute name="style">background-color: #222</xsl:attribute> </xsl:when>
+    <xsl:when test="$true_col=1 or $true_col=7"> <xsl:attribute name="style">background-color: #222</xsl:attribute> </xsl:when>
+    <xsl:when test="$true_row &lt; 3 or $true_row &gt; 5 or $true_col &lt; 3 or $true_col &gt; 5"> <xsl:attribute name="style">background-color: #888</xsl:attribute> </xsl:when>
+  </xsl:choose>  
+
+  <center>
+  <xsl:choose>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='lightDisc']"> <img class="piece" src="&ROOT;/resources/images/discs/red.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='lightPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Pawn.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='lightChecker']"> <img class="piece" src="&ROOT;/resources/images/checkers/red_king.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='lightKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/White_Knight.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='darkDisc']"> <img class="piece" src="&ROOT;/resources/images/discs/black.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='darkPawn']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Pawn.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='darkChecker']"> <img class="piece" src="&ROOT;/resources/images/checkers/black_king.png"/> </xsl:when>
+    <xsl:when test="//fact[relation='cell' and argument[1]=$true_row and argument[2]=$true_col and argument[3]='darkKnight']"> <img class="piece" src="&ROOT;/resources/images/chess/Black_Knight.png"/> </xsl:when>
+  </xsl:choose>
+  </center>
+  
+  </td>  
+</xsl:template>
+
+<xsl:template name="board_row">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+  <xsl:param name="col" select="1"/>
+  
+  <xsl:call-template name="cell">
+    <xsl:with-param name="row" select="$row"/>
+    <xsl:with-param name="col" select="$col"/>
+  </xsl:call-template>
+
+  <xsl:if test="$col &lt; $cols">
+    <xsl:call-template name="board_row">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row"/>
+      <xsl:with-param name="col" select="$col + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board_rows">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>  
+  <xsl:param name="row" select="1"/>
+
+  <tr>
+  <xsl:call-template name="board_row">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+    <xsl:with-param name="row" select="$row"/>
+  </xsl:call-template>
+  </tr>
+
+  <xsl:if test="$row &lt; $rows">
+    <xsl:call-template name="board_rows">
+      <xsl:with-param name="cols" select="$cols"/>
+      <xsl:with-param name="rows" select="$rows"/>
+      <xsl:with-param name="row" select="$row + 1"/>
+    </xsl:call-template>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template name="board">
+  <xsl:param name="cols" select="1"/>
+  <xsl:param name="rows" select="1"/>
+
+  <table class="board">
+  <xsl:call-template name="board_rows">
+    <xsl:with-param name="cols" select="$cols"/>
+    <xsl:with-param name="rows" select="$rows"/>
+  </xsl:call-template>
+  </table>
+</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
I looked for files that had a match for the regex "\r[^\n]" and had Eclipse convert the line endings to Windows-style. (Could have alternatively converted these to Unix-style, but we already have a mix and I suspect support for Windows line endings among Unix programs is slightly better than vice versa.)

This pull request shows how much these types of line endings confuse git.